### PR TITLE
Add syntax highlighting configuration

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -1,25 +1,23 @@
 #include "ted.h"
 
 void syntaxHighlight(unsigned int at) {
-    const char *strings[] = {"if", "else", "int ", "char ", "*" , "\"", "\'", "//", "unsigned ", "long ", "double ", "float ", "struct ", "const ", "return", ";" };
-    uint8_t colors[]      = {0x10, 0x10  , 0x20  , 0x20   , 0x30, 0x40, 0x40, 0x50, 0x20       , 0x20   , 0x20     , 0x20    , 0x20     , 0x20    , 0x30    , 0x30};
-    unsigned int slen = sizeof(strings) / sizeof(char *);
     for (unsigned int i = 0; i < lines[at].length; i++) {
         lines[at].color[i] = 0x0;
-        for (unsigned int k = 0; k < slen; k++) {
-            if (lines[at].length - i < strlen(strings[k]))
+        for (unsigned int k = 0; k < config.kwdlen; k++) {
+            unsigned int stringlen = strlen(config.keywords[k].string);
+            if (lines[at].length - i < stringlen)
                 continue;
             bool c = 0;
-            for (unsigned int j = 0; j < strlen(strings[k]); j++)
-                if ((uchar32_t)strings[k][j] != lines[at].data[i + j]) {
+            for (unsigned int j = 0; j < stringlen; j++)
+                if ((uchar32_t)config.keywords[k].string[j] != lines[at].data[i + j]) {
                     c = 1;
                     break;
                 }
             if (c)
                 continue;
-            for (unsigned int j = 0; j < strlen(strings[k]); j++)
-                lines[at].color[i + j] = colors[k];
-            i += strlen(strings[k]) - 1;
+            for (unsigned int j = 0; j < stringlen; j++)
+                lines[at].color[i + j] = config.keywords[k].color;
+            i += stringlen - 1;
             break;
         }
     }

--- a/src/ted.c
+++ b/src/ted.c
@@ -20,7 +20,13 @@ void setcolor(int c) {
 
 unsigned int last_cursor_x = 0;
 
-struct CFG config = {4, 0, 0, 1, 1};
+struct CFG config = {
+    4, 0, 0, 1, 1,
+    15, {
+    {"if", 0x10}, {"else", 0x10}, {"int", 0x20}, {"char", 0x20}, {"unsigned", 0x20},
+    {"double", 0x20}, {"float", 0x20}, {"struct", 0x20}, {"const", 0x20}, {"return", 0x20},
+    {"*", 0x30}, {"\"", 0x40}, {"\'", 0x40}, {"//", 0x50}, {";", 0x30}, {"!", 0x30}
+}};
 
 unsigned int display_cx() {
     unsigned int ret = cx;

--- a/src/ted.h
+++ b/src/ted.h
@@ -60,12 +60,19 @@ uint16_t utf8ToMultibyte(uchar32_t c, unsigned char *out);
 void syntaxHighlight(unsigned int at);
 void readColor(unsigned int at, unsigned int at1, unsigned char *fg, unsigned char *bg);
 
+struct KWD {
+    const char *string;
+    uint8_t color;
+};
+
 struct CFG {
     unsigned int tablen;
     unsigned int LINES;
     unsigned char line_break_type : 2; // 0: LF  1: CRLF  2: CR
     unsigned char use_spaces : 1;
     unsigned char autotab : 1;
+    unsigned int kwdlen;
+    struct KWD keywords[];
 };
 
 


### PR DESCRIPTION
Add support for customizable/configurable syntax highlighting.
Note: `struct KWD keywords[];` uses a c99 flexible array member.