### PR TITLE
Add support for syntax highlighting for multiple langs

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -14,15 +14,15 @@ void syntaxHighlight(void) {
         bool comment = 0;
         for (unsigned int i = 0; i <= lines[at].length; i++) {
             if (lines[at].data[i] == '\\') {
-                lines[at].color[i] = string ? config.syntax_string_color : 0x0;
+                lines[at].color[i] = string ? config.current_syntax->syntax_string_color : 0x0;
                 backslash = !backslash;
                 continue;
             }
-            if (!(comment || multi_line_comment) && strchr(config.stringchars, lines[at].data[i]) && !backslash) {
+            if (!(comment || multi_line_comment) && strchr(config.current_syntax->stringchars, lines[at].data[i]) && !backslash) {
                 if (!string)
                     string = lines[at].data[i];
                 else if (lines[at].data[i] == (uchar32_t)string) {
-                    lines[at].color[i] = config.syntax_string_color;
+                    lines[at].color[i] = config.current_syntax->syntax_string_color;
                     string = '\0';
                     continue;
                 }
@@ -31,63 +31,63 @@ void syntaxHighlight(void) {
             backslash = 0;
             
             if (string) {
-                lines[at].color[i] = config.syntax_string_color;
+                lines[at].color[i] = config.current_syntax->syntax_string_color;
                 continue;
             }
         
-            unsigned int slinecommentlen   = strlen(config.singleline_comment);
-            unsigned int mlinecommentstart = strlen(config.multiline_comment[0]);
-            unsigned int mlinecommentend   = strlen(config.multiline_comment[1]);
+            unsigned int slinecommentlen   = strlen(config.current_syntax->singleline_comment);
+            unsigned int mlinecommentstart = strlen(config.current_syntax->multiline_comment[0]);
+            unsigned int mlinecommentend   = strlen(config.current_syntax->multiline_comment[1]);
             char *datachar = malloc(lines[at].length + 1);
             
             for (unsigned int l = 0; l <= lines[at].length; l++)
                 datachar[l] = (char)lines[at].data[l];
                 
             if (lines[at].length >= slinecommentlen && i <= lines[at].length - slinecommentlen
-            && memcmp(&datachar[i], config.singleline_comment, slinecommentlen) == 0)
+            && memcmp(&datachar[i], config.current_syntax->singleline_comment, slinecommentlen) == 0)
                 comment = 1;
             else if (lines[at].length >= slinecommentlen && i <= lines[at].length - mlinecommentstart
-            && memcmp(&datachar[i], config.multiline_comment[0], mlinecommentstart) == 0)
+            && memcmp(&datachar[i], config.current_syntax->multiline_comment[0], mlinecommentstart) == 0)
                 multi_line_comment = 1;
             else if (i >= mlinecommentend
-            && memcmp(&datachar[i - mlinecommentend], config.multiline_comment[1], mlinecommentend) == 0)
+            && memcmp(&datachar[i - mlinecommentend], config.current_syntax->multiline_comment[1], mlinecommentend) == 0)
                 multi_line_comment = 0;
                 
             free(datachar);
             
-            lines[at].color[i] = comment || multi_line_comment ? config.syntax_comment_color : 0x0;
+            lines[at].color[i] = comment || multi_line_comment ? config.current_syntax->syntax_comment_color : 0x0;
             if (comment || multi_line_comment) continue;
             
             // if lines[at].data[i] is a null byte, strchr will return
             if (lines[at].data[i] && 
-                (strchr(config.match[0], lines[at].data[i]) || strchr(config.match[1], lines[at].data[i]))
+                (strchr(config.current_syntax->match[0], lines[at].data[i]) || strchr(config.current_syntax->match[1], lines[at].data[i]))
             ) {
-                bool opening = strchr(config.match[0], lines[at].data[i]);
+                bool opening = strchr(config.current_syntax->match[0], lines[at].data[i]);
                 
                 if (waiting_to_close && !opening) {
                     if (waiting_to_close == 1)
-                        lines[at].color[i] = config.match_color;
+                        lines[at].color[i] = config.current_syntax->match_color;
                     waiting_to_close--;
                     continue;
                 } else if (waiting_to_close && opening)
                     waiting_to_close++;
                 
                 if (at == cursor.y && i + 1 == cursor.x) {
-                    lines[at].color[i] = config.match_color;
+                    lines[at].color[i] = config.current_syntax->match_color;
                     if (opening) {
                         waiting_to_close = 1;
                     } else {
                         unsigned int lay = 1;
                         for (int _at = at; _at >= 0; _at--) {
                             for (int _i = (int)at == _at ? i : lines[_at].length - 1; _i >= 0; _i--) {
-                                if (strchr(config.match[0], lines[_at].data[_i])) {
+                                if (strchr(config.current_syntax->match[0], lines[_at].data[_i])) {
                                     lay--;
                                     if (lay == 1) {
-                                        lines[_at].color[_i] = config.match_color;
+                                        lines[_at].color[_i] = config.current_syntax->match_color;
                                         _at = -1;
                                         break;
                                     }
-                                } else if (strchr(config.match[1], lines[_at].data[_i])) {
+                                } else if (strchr(config.current_syntax->match[1], lines[_at].data[_i])) {
                                     lay++;
                                 }
                             }
@@ -97,18 +97,18 @@ void syntaxHighlight(void) {
             }
             
             
-            for (unsigned int k = 0; k < config.kwdlen; k++) {
-                unsigned int stringlen = strlen(config.keywords[k].string);
+            for (unsigned int k = 0; k < config.current_syntax->kwdlen; k++) {
+                unsigned int stringlen = strlen(config.current_syntax->keywords[k].string);
                 if (lines[at].length - i < stringlen) continue;
                 bool c = 0;
                 for (unsigned int j = 0; j < stringlen; j++)
-                    if ((uchar32_t)config.keywords[k].string[j] != lines[at].data[i + j]) {
+                    if ((uchar32_t)config.current_syntax->keywords[k].string[j] != lines[at].data[i + j]) {
                         c = 1;
                         break;
                     }
                 if (c) continue;
                 for (unsigned int j = 0; j < stringlen; j++)
-                    lines[at].color[i + j] = config.keywords[k].color;
+                    lines[at].color[i + j] = config.current_syntax->keywords[k].color;
                 i += stringlen - 1;
                 break;
             }

--- a/src/config_dialog.c
+++ b/src/config_dialog.c
@@ -58,13 +58,28 @@ void manual(char *data) {
     free(data);
 }
 void syntax (char *data) {
-    if (strcmp(data, "TRUE") == 0 || strcmp(data, "1") == 0)
-        config.syntax_on = 1;
-    else if (strcmp(data, "FALSE") == 0 || strcmp(data, "0") == 0)
+    if (!*data) {
         config.syntax_on = 0;
-    else
-        beep();
-    syntaxHighlight();
+        return;
+    }
+
+    unsigned int len = (unsigned int)strlen(data);
+    for (unsigned int i = 0; i < config.syntax_len; ++i) {
+        struct SHD *syntax = config.syntaxes[i];
+
+        for (unsigned int j = 0; j < syntax->exts_len; ++j) {
+            unsigned int ext_len = (unsigned int)strlen(syntax->extensions[j]);
+            if (len == ext_len && strcmp(data, syntax->extensions[j]) == 0) {
+                config.syntax_on = 1;
+                config.current_syntax = syntax;
+                syntaxHighlight();
+                free(data);
+                return;
+            }
+        }
+    }
+
+    beep();
     free(data);
 }
 
@@ -73,13 +88,13 @@ struct {
     const char *message;
     void (*function)(char *data);
 } fns[] = {
-    {"tablen"    , "tablen: "                            , tablen    },
-    {"linebreak" , "linebreak (LF, CR, CRLF): "          , linebreak },
-    {"use-spaces", "use-spaces (0/FALSE, 1/TRUE): "      , use_spaces},
-    {"autotab"   , "autotab (0/FALSE, 1/TRUE): "         , autotab   },
-    {"save-as"   , "save-as: "                           , save_as   },
-    {"manual"    , "manual page (blank for index): "     , manual    },
-    {"syntax"    , "syntax highlight (0/FALSE, 1/TRUE): ", syntax    }
+    {"tablen"    , "tablen: "                                , tablen    },
+    {"linebreak" , "linebreak (LF, CR, CRLF): "              , linebreak },
+    {"use-spaces", "use-spaces (0/FALSE, 1/TRUE): "          , use_spaces},
+    {"autotab"   , "autotab (0/FALSE, 1/TRUE): "             , autotab   },
+    {"save-as"   , "save-as: "                               , save_as   },
+    {"manual"    , "manual page (blank for index): "         , manual    },
+    {"syntax"    , "syntax highlight (blank for disabling): ", syntax    }
 };
 
 void config_dialog(void) {

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -96,9 +96,9 @@ void process_keypress(int c) {
     } case ctrl('w'): {
         // Calling 'syntaxHighlight' is not needed here because calling 'process_keypress(KEY_BACKSPACE)' does it
         bool passed_spaces = 0;
-        while (cx > 0 && (!strchr(config.current_syntax->word_separators, lines[cy].data[cx - 1]) || !passed_spaces)) {
+        while (cx > 0 && (!(config.syntax_on && strchr(config.current_syntax->word_separators, lines[cy].data[cx - 1])) || !passed_spaces)) {
             process_keypress(KEY_BACKSPACE);
-            if (cx > 0 && !strchr(config.current_syntax->word_separators, lines[cy].data[cx - 1]))
+            if (cx > 0 && !(config.syntax_on && strchr(config.current_syntax->word_separators, lines[cy].data[cx - 1])))
                 passed_spaces = 1;
         }
         break;
@@ -114,17 +114,17 @@ void process_keypress(int c) {
         char passed_spaces = 0;
         while (cx > 0) {
             process_keypress(KEY_LEFT);
-            if (!strchr(config.current_syntax->word_separators, lines[cy].data[cx]))
+            if (!(config.syntax_on && strchr(config.current_syntax->word_separators, lines[cy].data[cx])))
                 passed_spaces = 1;
-            if (strchr(config.current_syntax->word_separators, lines[cy].data[cx]) && passed_spaces) {
+            if ((config.syntax_on && strchr(config.current_syntax->word_separators, lines[cy].data[cx])) && passed_spaces) {
                 process_keypress(KEY_RIGHT);
                 break;
             }
         }
     } else if (c == CTRL_KEY_RIGHT) {
         char passed_spaces = 0;
-        while (lines[cy].data[cx] != '\0' && !(strchr(config.current_syntax->word_separators, lines[cy].data[cx]) && passed_spaces)) {
-            if (!strchr(config.current_syntax->word_separators, lines[cy].data[cx]))
+        while (lines[cy].data[cx] != '\0' && !((config.syntax_on && strchr(config.current_syntax->word_separators, lines[cy].data[cx])) && passed_spaces)) {
+            if (!(config.syntax_on && strchr(config.current_syntax->word_separators, lines[cy].data[cx])))
                 passed_spaces = 1;
             process_keypress(KEY_RIGHT);
         }

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -96,9 +96,9 @@ void process_keypress(int c) {
     } case ctrl('w'): {
         // Calling 'syntaxHighlight' is not needed here because calling 'process_keypress(KEY_BACKSPACE)' does it
         bool passed_spaces = 0;
-        while (cx > 0 && (!strchr(config.word_separators, lines[cy].data[cx - 1]) || !passed_spaces)) {
+        while (cx > 0 && (!strchr(config.current_syntax->word_separators, lines[cy].data[cx - 1]) || !passed_spaces)) {
             process_keypress(KEY_BACKSPACE);
-            if (cx > 0 && !strchr(config.word_separators, lines[cy].data[cx - 1]))
+            if (cx > 0 && !strchr(config.current_syntax->word_separators, lines[cy].data[cx - 1]))
                 passed_spaces = 1;
         }
         break;
@@ -114,17 +114,17 @@ void process_keypress(int c) {
         char passed_spaces = 0;
         while (cx > 0) {
             process_keypress(KEY_LEFT);
-            if (!strchr(config.word_separators, lines[cy].data[cx]))
+            if (!strchr(config.current_syntax->word_separators, lines[cy].data[cx]))
                 passed_spaces = 1;
-            if (strchr(config.word_separators, lines[cy].data[cx]) && passed_spaces) {
+            if (strchr(config.current_syntax->word_separators, lines[cy].data[cx]) && passed_spaces) {
                 process_keypress(KEY_RIGHT);
                 break;
             }
         }
     } else if (c == CTRL_KEY_RIGHT) {
         char passed_spaces = 0;
-        while (lines[cy].data[cx] != '\0' && !(strchr(config.word_separators, lines[cy].data[cx]) && passed_spaces)) {
-            if (!strchr(config.word_separators, lines[cy].data[cx]))
+        while (lines[cy].data[cx] != '\0' && !(strchr(config.current_syntax->word_separators, lines[cy].data[cx]) && passed_spaces)) {
+            if (!strchr(config.current_syntax->word_separators, lines[cy].data[cx]))
                 passed_spaces = 1;
             process_keypress(KEY_RIGHT);
         }

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -12,7 +12,7 @@ static struct KWD c_cpp_kwd[] = {
     {"*", 0x30}, {";", 0x30}, {",", 0x30}
 };
 
-static const char *c_cpp_exts[] = {".c", ".h", ".cpp", ".hpp", ".cc", ".hh"};
+static const char *c_cpp_exts[] = {"c", "h", "cpp", "hpp", "cc", "hh"};
 
 static struct SHD c_cpp_syntax = {
     sizeof c_cpp_exts / sizeof *c_cpp_exts, c_cpp_exts,

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -1,0 +1,35 @@
+#include "syntax.h"
+
+/*
+C and C++ syntax highlighting descriptor
+*/
+
+static struct KWD c_cpp_kwd[] = {
+    {"if", 0x10}, {"else", 0x10}, {"while", 0x10}, {"for", 0x10},
+    {"int", 0x20}, {"char", 0x20}, {"unsigned", 0x20}, {"double", 0x20},
+    {"float", 0x20}, {"struct", 0x20}, {"const", 0x20}, {"return", 0x20},
+    {"void", 0x20},
+    {"*", 0x30}, {";", 0x30}, {",", 0x30}
+};
+
+static const char *c_cpp_exts[] = {".c", ".h", ".cpp", ".hpp", ".cc", ".hh"};
+
+static struct SHD c_cpp_syntax = {
+    sizeof c_cpp_exts / sizeof *c_cpp_exts, c_cpp_exts,
+    " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?", // Characters that separates words
+    sizeof c_cpp_kwd / sizeof *c_cpp_kwd, c_cpp_kwd, //Keywords
+    0x40, 0x50, 0x05,
+    "\"\'`", // Strings charaters
+    "//", {"/*", "*/"}, // Comments
+    {"{[(", ")]}"}
+};
+
+/*
+Global syntaxes
+*/
+struct SHD *syntaxes[] = {&c_cpp_syntax};
+
+void register_syntax(void) {
+    config.syntaxes = syntaxes;
+    config.syntax_len = sizeof syntaxes / sizeof *syntaxes;
+}

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -1,0 +1,10 @@
+#ifndef SYNTAX_HEADER
+#define SYNTAX_HEADER
+
+#include "ted.h"
+
+extern struct SHD *syntaxes[];
+
+void register_syntax(void);
+
+#endif

--- a/src/ted.c
+++ b/src/ted.c
@@ -1,4 +1,5 @@
 #include "ted.h"
+#include "syntax.h"
 
 struct LINE *lines = NULL;
 unsigned int num_lines;
@@ -21,24 +22,9 @@ void setcolor(int c) {
 
 unsigned int last_cursor_x = 0;
 
-struct KWD kwd[] = {
-    {"if", 0x10}, {"else", 0x10}, {"while", 0x10}, {"for", 0x10},
-    {"int", 0x20}, {"char", 0x20}, {"unsigned", 0x20}, {"double", 0x20},
-    {"float", 0x20}, {"struct", 0x20}, {"const", 0x20}, {"return", 0x20},
-    {"void", 0x20},
-    {"*", 0x30}, {";", 0x30}, {",", 0x30}
-};
-
 struct CFG config = {
     4, 0, 0, 1, 1,
-    0, // Syntax ON or OFF (It is changed to ON if the file ends with .c, .cpp, .h or .hpp
-    " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?", // Characters that separates words
-    0, // kwdlen is automatically calculated
-    kwd,
-    0x40, 0x50, 0x05,
-    "\"\'`", // Strings charaters
-    "//", {"/*", "*/"}, // Comments
-    {"{[(", ")]}"}
+    0, NULL, 0, NULL
 };
 
 int main(int argc, char **argv) {
@@ -84,16 +70,24 @@ int main(int argc, char **argv) {
     mousemask(ALL_MOUSE_EVENTS, NULL);
     mouseinterval(1);
     curs_set(0);
-    
-    config.kwdlen = sizeof kwd / sizeof *kwd;
-    unsigned int filename_length = (unsigned int)strlen(filename);
-    if  (   (filename_length >= 2 && strcmp(&filename[filename_length - 2], ".c"  ) == 0) ||
-            (filename_length >= 2 && strcmp(&filename[filename_length - 2], ".h"  ) == 0) ||
-            (filename_length >= 4 && strcmp(&filename[filename_length - 4], ".cpp") == 0) ||
-            (filename_length >= 4 && strcmp(&filename[filename_length - 4], ".hpp") == 0)
-        )
-        config.syntax_on = 1;
-        
+
+    register_syntax();
+
+    unsigned int filename_len = (unsigned int)strlen(filename);
+    for (unsigned int i = 0; i < config.syntax_len; ++i) {
+        struct SHD *syntax = config.syntaxes[i];
+
+        for (unsigned int j = 0; j < syntax->exts_len; ++j) {
+            unsigned int ext_len = (unsigned int)strlen(syntax->extensions[j]);
+            if (filename_len >= ext_len && strcmp(&filename[filename_len - ext_len], ".c"  ) == 0) {
+                config.syntax_on = 1;
+                config.current_syntax = syntax;
+                goto out;
+            }
+        }
+    }
+
+out:;
 
     char tmp[10];
     len_line_number = snprintf(tmp, 10, "%d ", num_lines + 1);

--- a/src/ted.c
+++ b/src/ted.c
@@ -79,7 +79,9 @@ int main(int argc, char **argv) {
 
         for (unsigned int j = 0; j < syntax->exts_len; ++j) {
             unsigned int ext_len = (unsigned int)strlen(syntax->extensions[j]);
-            if (filename_len >= ext_len && strcmp(&filename[filename_len - ext_len], ".c"  ) == 0) {
+            if (filename_len >= ext_len + 1 &&
+                filename[filename_len - (ext_len + 1)] == '.' &&
+                strcmp(&filename[filename_len - ext_len], syntax->extensions[j]) == 0) {
                 config.syntax_on = 1;
                 config.current_syntax = syntax;
                 goto out;

--- a/src/ted.h
+++ b/src/ted.h
@@ -1,3 +1,6 @@
+#ifndef TED_HEADER
+#define TED_HEADER
+
 #include <ncurses.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -76,13 +79,12 @@ struct KWD {
     uint8_t color;
 };
 
-struct CFG {
-    unsigned int tablen;
-    int lines;
-    unsigned char line_break_type; // 0: LF  1: CRLF  2: CR
-    bool use_spaces;
-    bool autotab;
-    bool syntax_on;
+/*
+Syntax Highlighting Descriptor
+*/
+struct SHD {
+    unsigned int exts_len;
+    const char **extensions;
     const char *word_separators;
     unsigned int kwdlen;
     struct KWD *keywords;
@@ -95,6 +97,17 @@ struct CFG {
     const char *match[2];
 };
 
+struct CFG {
+    unsigned int tablen;
+    int lines;
+    unsigned char line_break_type; // 0: LF  1: CRLF  2: CR
+    bool use_spaces;
+    bool autotab;
+    bool syntax_on;
+    struct SHD *current_syntax;
+    unsigned int syntax_len;
+    struct SHD **syntaxes;
+};
 
 /*
 ffffbbbb
@@ -136,3 +149,5 @@ extern unsigned int last_cursor_x;
 extern bool colors_on;
 extern bool needs_to_free_filename;
 extern char *menu_message;
+
+#endif


### PR DESCRIPTION
Adding a new language syntax should be pretty straight forward and can be accomplished just by adding the needed struct in syntax.c and updating `struct SHD *syntaxes[]`. The user can now specify which highlighting syntax should be applied in the config dialog. Filenames extensions are linearly probed in order to check if a syntax highlighting descriptor can be applied (This can be improved by using a constant time lookup table, like an hashmap).