### PR TITLE
Fix keyword matching

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -96,10 +96,14 @@ void syntaxHighlight(void) {
                 }
             }
             
-            
             for (unsigned int k = 0; k < config.current_syntax->kwdlen; k++) {
                 unsigned int stringlen = strlen(config.current_syntax->keywords[k].string);
                 if (lines[at].length - i < stringlen) continue;
+
+                if ((i != 0 && !strchr(config.current_syntax->word_separators, lines[at].data[i - 1]))
+                    || !strchr(config.current_syntax->word_separators, lines[at].data[i + stringlen]))
+                    continue;
+
                 bool c = 0;
                 for (unsigned int j = 0; j < stringlen; j++)
                     if ((uchar32_t)config.current_syntax->keywords[k].string[j] != lines[at].data[i + j]) {
@@ -120,4 +124,3 @@ void readColor(unsigned int at, unsigned int at1, unsigned char *fg, unsigned ch
     *fg = (lines[at].color[at1] & 0xF0) >> 4;
     *bg = lines[at].color[at1] & 0x0F;
 }
-

--- a/src/config_dialog.c
+++ b/src/config_dialog.c
@@ -60,6 +60,7 @@ void manual(char *data) {
 void syntax (char *data) {
     if (!*data) {
         config.syntax_on = 0;
+        free(data);
         return;
     }
 


### PR DESCRIPTION
Now keywords don't match if there isn't a separator (or line start) before and after them. 
For example: `for` in `fortunate` now will not be highlighted.