### PR TITLE
Add operator keywords support

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -100,9 +100,11 @@ void syntaxHighlight(void) {
                 unsigned int stringlen = strlen(config.current_syntax->keywords[k].string);
                 if (lines[at].length - i < stringlen) continue;
 
-                if ((i != 0 && !strchr(config.current_syntax->word_separators, lines[at].data[i - 1]))
-                    || !strchr(config.current_syntax->word_separators, lines[at].data[i + stringlen]))
-                    continue;
+                if (!config.current_syntax->keywords[k].operator) {
+                    if ((i != 0 && !strchr(config.current_syntax->word_separators, lines[at].data[i - 1]))
+                        || !strchr(config.current_syntax->word_separators, lines[at].data[i + stringlen]))
+                        continue;
+                }
 
                 bool c = 0;
                 for (unsigned int j = 0; j < stringlen; j++)

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -5,11 +5,18 @@ C and C++ syntax highlighting descriptor
 */
 
 static struct KWD c_cpp_kwd[] = {
-    {"if", 0x10}, {"else", 0x10}, {"while", 0x10}, {"for", 0x10},
-    {"int", 0x20}, {"char", 0x20}, {"unsigned", 0x20}, {"double", 0x20},
-    {"float", 0x20}, {"struct", 0x20}, {"const", 0x20}, {"return", 0x20},
-    {"void", 0x20},
-    {"*", 0x30}, {";", 0x30}, {",", 0x30}
+    KEYWORD("if", 0x10), KEYWORD("else", 0x10), KEYWORD("while", 0x10),
+    KEYWORD("for", 0x10), KEYWORD("return", 0x10), KEYWORD("static", 0x10),
+
+    KEYWORD("int", 0x20), KEYWORD("char", 0x20), KEYWORD("unsigned", 0x20), 
+    KEYWORD("long", 0x20), KEYWORD("double", 0x20), KEYWORD("float", 0x20), 
+    KEYWORD("struct", 0x20), KEYWORD("const", 0x20), KEYWORD("void", 0x20), 
+
+    OPERATOR("*", 0x30), OPERATOR(",", 0x30), OPERATOR(";", 0x30), 
+    OPERATOR("!", 0x30), OPERATOR("&&", 0x30), OPERATOR("||", 0x30),
+    OPERATOR("&", 0x30), OPERATOR("|", 0x30), OPERATOR("~", 0x30),
+    OPERATOR("^", 0x30), OPERATOR(">>", 0x30), OPERATOR("<<", 0x30),
+    OPERATOR("+", 0x30), OPERATOR("-", 0x30), OPERATOR("/", 0x30),
 };
 
 static const char *c_cpp_exts[] = {"c", "h", "cpp", "hpp", "cc", "hh"};

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -3,6 +3,9 @@
 
 #include "ted.h"
 
+#define KEYWORD(name, color)        {name, color, 0}
+#define OPERATOR(operator, color)   {operator, color, 1}
+
 extern struct SHD *syntaxes[];
 
 void register_syntax(void);

--- a/src/ted.h
+++ b/src/ted.h
@@ -76,7 +76,8 @@ void freeBuffers(void);
 
 struct KWD {
     const char *string;
-    uint8_t color;
+    unsigned int color;
+    bool operator;
 };
 
 /*


### PR DESCRIPTION
This pr is an improvement of #20 
This adds a way for operators to match even if directly before or after a non-separating character is present.  I added a pair of utility macros for declaring keywords and operators, and also expanded a little bit the syntax keywords.

For example: in `a+b; a&&b;` + and && will match, however struct won't match in `astructb`.