### PR TITLE
Minor fix to detect_extension

### DIFF
--- a/src/extension.c
+++ b/src/extension.c
@@ -13,12 +13,11 @@ void detect_extension(void) {
     
     for (unsigned int i = 0; i < config.syntax_len; i++) {
         struct SHD *syntax = config.syntaxes[i];
-        
         for (unsigned int j = 0; j < syntax->exts_len; j++) {
             int sextlen = strlen(syntax->extensions[j]);
             
             // fextlen == sextlen can be removed, but it gives more speed
-            if (fextlen == sextlen && !strcmp(ext, syntax->extensions[j])) {
+            if (fextlen == sextlen && !strncmp(ext, syntax->extensions[j], fextlen)) {
                 config.syntax_on = 1;
                 config.current_syntax = syntax;
                 return;
@@ -28,5 +27,3 @@ void detect_extension(void) {
     
     config.syntax_on = 0;
 }
-
-

--- a/src/ted.h
+++ b/src/ted.h
@@ -77,7 +77,6 @@ void prevBuffer(void);
 void freeBuffers(void);
 
 // extension.c
-
 void detect_extension(void);
 
 struct KWD {


### PR DESCRIPTION
Minor fix to `detect_extension`. Using `strncmp` instead of `strcmp` should be faster since lengths are already been calculated.