### PR TITLE
Read only buffers

### DIFF
--- a/src/config_dialog.c
+++ b/src/config_dialog.c
@@ -73,6 +73,7 @@ static void save_as(char **words, unsigned int words_len) {
         filename[size - 1] = '\0';
 
         needs_to_free_filename = 1;
+        read_only = 0; // todo: check if the new filename is read only
         savefile();
     } else
         beep();
@@ -81,11 +82,13 @@ static void save_as(char **words, unsigned int words_len) {
 static void manual(char **words, unsigned int words_len) {
     if (words_len == 0) {
         openFile(home_path(".config/ted/docs/help.txt"), 1);
+        read_only = 1;
 
-    } else if (words_len == 0) {
+    } else if (words_len == 1) {
         char fname[1000];
         snprintf(fname, 1000, ".config/ted/docs/%s.txt", words[0]);
         openFile(home_path(fname), 1);
+        read_only = 1;
     } else
         beep();
 }

--- a/src/config_dialog.c
+++ b/src/config_dialog.c
@@ -44,11 +44,14 @@ static void save_as(char **words, unsigned int words_len) {
         if (needs_to_free_filename)
             free(filename);
 
-        filename = malloc(sizeof(words[0]));
-        strcpy(filename, words[0]);
+        unsigned int size = (strlen(words[0]) + 1) * sizeof(char);
+        filename = malloc(size);
+        memcpy(filename, words[0], size);
         needs_to_free_filename = 1;
-        read_only = 0; // todo: check if the new filename is read only
-        savefile();
+        detect_read_only(filename);
+
+        if (read_only) message("Can't save as a read-only file.");
+        else savefile();
     }
 }
 

--- a/src/config_dialog.c
+++ b/src/config_dialog.c
@@ -66,9 +66,9 @@ static void manual(char **words, unsigned int words_len) {
 
 static void syntax(char **words, unsigned int words_len) {
     if (words_len == 1) {
-        char *str = malloc(strlen(words[1]) + 2);
+        char *str = malloc(strlen(words[0]) + 2);
         *str = '.';
-        strcpy(str + 1, words[1]);
+        strcpy(str + 1, words[0]);
 
         if (!detect_extension(str))
             config.current_syntax = &default_syntax;

--- a/src/open_and_save.c
+++ b/src/open_and_save.c
@@ -141,11 +141,18 @@ void openFile(char *fname, bool needs_to_free) {
     if (fp != NULL)
         fclose(fp);
 
-    struct stat st;
-    if (stat(fname, &st) == 0)
-        read_only = (st.st_mode & S_IWUSR) || (st.st_mode & S_IWGRP);
-    
     char tmp[10];
     len_line_number = snprintf(tmp, 10, "%d", num_lines + 1);
+    detect_read_only(fname);
 }
 
+void detect_read_only(char *fname) {
+    struct stat st;
+    if (stat(fname, &st) == 0) {
+        read_only = !(
+            (st.st_mode & S_IWOTH)
+            || (getuid() == st.st_uid && (st.st_mode & S_IWUSR))
+            || (getgid() == st.st_gid && (st.st_mode & S_IWGRP))
+        );
+    }
+}

--- a/src/open_and_save.c
+++ b/src/open_and_save.c
@@ -140,6 +140,10 @@ void openFile(char *fname, bool needs_to_free) {
     read_lines();
     if (fp != NULL)
         fclose(fp);
+
+    struct stat st;
+    if (stat(fname, &st) == 0)
+        read_only = (st.st_mode & S_IWUSR) || (st.st_mode & S_IWGRP);
     
     char tmp[10];
     len_line_number = snprintf(tmp, 10, "%d", num_lines + 1);

--- a/src/open_and_save.c
+++ b/src/open_and_save.c
@@ -154,5 +154,6 @@ void detect_read_only(char *fname) {
             || (getuid() == st.st_uid && (st.st_mode & S_IWUSR)) // owner write permission
             || (getgid() == st.st_gid && (st.st_mode & S_IWGRP)) // group write permission
         );
-    }
+    } else
+        read_only = errno == EACCES; // if stat fails and errno is not EACCES, read_only will not be set
 }

--- a/src/open_and_save.c
+++ b/src/open_and_save.c
@@ -8,7 +8,6 @@ void savefile(void) {
         snprintf(buf, 1000, "Could not open the file\nErrno: %d\nPress any key", errno);
 
         message(buf);
-
         return;
     }
     

--- a/src/open_and_save.c
+++ b/src/open_and_save.c
@@ -150,9 +150,9 @@ void detect_read_only(char *fname) {
     struct stat st;
     if (stat(fname, &st) == 0) {
         read_only = !(
-            (st.st_mode & S_IWOTH)
-            || (getuid() == st.st_uid && (st.st_mode & S_IWUSR))
-            || (getgid() == st.st_gid && (st.st_mode & S_IWGRP))
+            (st.st_mode & S_IWOTH) // all user write permission
+            || (getuid() == st.st_uid && (st.st_mode & S_IWUSR)) // owner write permission
+            || (getgid() == st.st_gid && (st.st_mode & S_IWGRP)) // group write permission
         );
     }
 }

--- a/src/ted.c
+++ b/src/ted.c
@@ -89,6 +89,7 @@ int main(int argc, char **argv) {
     fp = fopen(filename, "r");
     read_lines();
     if (fp) fclose(fp);
+    detect_read_only(filename);
     
     int last_LINES = LINES;
     int last_COLS = COLS;

--- a/src/ted.c
+++ b/src/ted.c
@@ -14,6 +14,7 @@ char *menu_message = "";
 
 bool colors_on = 0;
 bool needs_to_free_filename;
+bool read_only = 0;
 
 void setcolor(int c) {
     if (colors_on)

--- a/src/ted.c
+++ b/src/ted.c
@@ -41,10 +41,6 @@ int main(int argc, char **argv) {
             mkdir(config_ted, 0777);
             
         filename = home_path(".config/ted/buffer");
-        
-        strcpy(filename, config_ted);
-        strcat(filename, "buffer");
-
         needs_to_free_filename = 1;
         free(config);
         free(config_ted);
@@ -97,7 +93,6 @@ int main(int argc, char **argv) {
     int last_LINES = LINES;
     int last_COLS = COLS;
     
-
     int c;
     while (1) {
         if (last_LINES != LINES || last_COLS != COLS) {

--- a/src/ted.h
+++ b/src/ted.h
@@ -163,6 +163,7 @@ extern struct TEXT_SCROLL text_scroll;
 extern unsigned int last_cursor_x;
 extern bool colors_on;
 extern bool needs_to_free_filename;
+extern bool read_only;
 extern char *menu_message;
 extern struct SHD default_syntax;
 

--- a/src/ted.h
+++ b/src/ted.h
@@ -48,6 +48,7 @@ void savefile(void);
 void read_lines(void);
 void detect_linebreak(void);
 void openFile(char *fname, bool needs_to_free);
+void detect_read_only(char *fname);
 
 // show.c
 void show_menu(char *message, char *shadow);

--- a/src/utils.c
+++ b/src/utils.c
@@ -56,7 +56,7 @@ char **split_str(const char *str, int *num_str) {
             while (*spc == ' ') spc++;
         }
 
-        strs = realloc(strs, ++*num_str * sizeof(*strs));
+        strs = realloc(strs, ++(*num_str) * sizeof(*strs));
 
         strs[*num_str - 1] = astr;
 
@@ -70,4 +70,3 @@ char **split_str(const char *str, int *num_str) {
 
     return strs;
 }
-


### PR DESCRIPTION
Initial implementation of read-only buffers (#30 ). Automatically sets read-only mode for manual files and can also detect if the file being open (in openFile and also in main) is read-only by using stat (I tested this on system file without root permissions and it worked).