### PR TITLE
Optimize syntax highlighting performance and fix segfault when config.current_syntax is not set

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -5,6 +5,11 @@ void syntaxHighlight(void) {
     bool backslash = 0;
     char string = '\0';
     unsigned int waiting_to_close = 0;
+
+    unsigned int slinecommentlen   = strlen(config.current_syntax->singleline_comment);
+    unsigned int mlinecommentstart = strlen(config.current_syntax->multiline_comment[0]);
+    unsigned int mlinecommentend   = strlen(config.current_syntax->multiline_comment[1]);
+
     for (unsigned int at = 0; at < text_scroll.y + config.lines; at++) {
         if (at == num_lines)
             break;
@@ -39,26 +44,25 @@ void syntaxHighlight(void) {
                 continue;
             }
         
-            unsigned int slinecommentlen   = strlen(config.current_syntax->singleline_comment);
-            unsigned int mlinecommentstart = strlen(config.current_syntax->multiline_comment[0]);
-            unsigned int mlinecommentend   = strlen(config.current_syntax->multiline_comment[1]);
             char *datachar = malloc(lines[at].length + 1);
-            
             for (unsigned int l = 0; l <= lines[at].length; l++)
                 datachar[l] = (char)lines[at].data[l];
                 
-            if (lines[at].length >= slinecommentlen && i <= lines[at].length - slinecommentlen
-            && memcmp(&datachar[i], config.current_syntax->singleline_comment, slinecommentlen) == 0)
+            if (slinecommentlen != 0
+                && lines[at].length >= slinecommentlen && i <= lines[at].length - slinecommentlen
+                && memcmp(&datachar[i], config.current_syntax->singleline_comment, slinecommentlen) == 0)
                 comment = 1;
-            else if (lines[at].length >= slinecommentlen && i <= lines[at].length - mlinecommentstart
-            && memcmp(&datachar[i], config.current_syntax->multiline_comment[0], mlinecommentstart) == 0)
+
+            else if (mlinecommentstart != 0
+                && lines[at].length >= slinecommentlen && i <= lines[at].length - mlinecommentstart
+                && memcmp(&datachar[i], config.current_syntax->multiline_comment[0], mlinecommentstart) == 0)
                 multi_line_comment = 1;
-            else if (i >= mlinecommentend
-            && memcmp(&datachar[i - mlinecommentend], config.current_syntax->multiline_comment[1], mlinecommentend) == 0)
+
+            else if (mlinecommentend != 0 && i >= mlinecommentend
+                && memcmp(&datachar[i - mlinecommentend], config.current_syntax->multiline_comment[1], mlinecommentend) == 0)
                 multi_line_comment = 0;
                 
             free(datachar);
-            
             lines[at].color[i] = comment || multi_line_comment ? config.current_syntax->syntax_comment_color : 0x0;
             if (comment || multi_line_comment) continue;
             
@@ -101,7 +105,7 @@ void syntaxHighlight(void) {
             }
             
             for (unsigned int k = 0; k < config.current_syntax->kwdlen; k++) {
-                unsigned int stringlen = strlen(config.current_syntax->keywords[k].string);
+                unsigned int stringlen = config.current_syntax->keywords[k].length;
                 if (lines[at].length - i < stringlen) continue;
 
                 if (!config.current_syntax->keywords[k].operator) {

--- a/src/show.c
+++ b/src/show.c
@@ -14,16 +14,15 @@ void show_menu(char *message, char *shadow) {
         printw("I:%u %s", lines[cy].ident, filename);
         char buf[256];
         int len = snprintf(buf, 256, "%s %s",
-                           config.current_syntax->name,
+                           config.syntax_on && config.current_syntax ? config.current_syntax->name : "Off",
                            config.line_break_type == 0 ? "LF" : (config.line_break_type == 1 ? "CRLF" : "CR"));
         mvprintw(config.lines, COLS - len, "%s", buf);
 
     } else if (shadow != NULL) {
         printw("%s", message);
-        getyx(stdscr, y, x);
+        getyx(stdscr, y, x); //save message x and y
 
-        // Grey
-        setcolor(COLOR_PAIR(5));
+        setcolor(COLOR_PAIR(5)); // Grey
         attron(A_BOLD);
         printw("%s", shadow);
 

--- a/src/show.c
+++ b/src/show.c
@@ -14,7 +14,7 @@ void show_menu(char *message, char *shadow) {
         printw("I:%u %s", lines[cy].ident, filename);
         char buf[256];
         int len = snprintf(buf, 256, "%s %s",
-                           config.syntax_on && config.current_syntax ? config.current_syntax->name : "Off",
+                           config.current_syntax ? config.current_syntax->name : "Off", // check if current_syntax is NULL
                            config.line_break_type == 0 ? "LF" : (config.line_break_type == 1 ? "CRLF" : "CR"));
         mvprintw(config.lines, COLS - len, "%s", buf);
 

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -127,7 +127,7 @@ static struct SHD sh_syntax = {
     sizeof sh_kwd / sizeof *sh_kwd, sh_kwd, //Keywords
     0x40, 0x50, 0x05,
     "\"\'`", // Strings charaters
-    "#", {": '", "'"}, // Comments
+    "#", {"", ""}, // Comments
     {"{[(", ")]}"}
 };
 

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -127,7 +127,7 @@ static struct SHD sh_syntax = {
     sizeof sh_kwd / sizeof *sh_kwd, sh_kwd, //Keywords
     0x40, 0x50, 0x05,
     "\"\'`", // Strings charaters
-    "#", {"", ""}, // Comments
+    "#", {": '", "'"}, // Comments
     {"{[(", ")]}"}
 };
 

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -3,8 +3,8 @@
 
 #include "ted.h"
 
-#define KEYWORD(name, color)        {name, color, 0}
-#define OPERATOR(operator, color)   {operator, color, 1}
+#define KEYWORD(name, color)    {name, color, sizeof(name) - sizeof(char), 0}
+#define OPERATOR(op, color)     {op, color, sizeof(op) - sizeof(char), 1}
 
 extern struct SHD *syntaxes[];
 

--- a/src/ted.c
+++ b/src/ted.c
@@ -25,7 +25,7 @@ unsigned int last_cursor_x = 0;
 
 struct CFG config = {
     4, 0, 0, 1, 1,
-    0, NULL, 0, NULL
+    0, &default_syntax, 0, NULL
 };
 
 int main(int argc, char **argv) {

--- a/src/ted.h
+++ b/src/ted.h
@@ -92,6 +92,7 @@ bool detect_extension(char *fname);
 struct KWD {
     const char *string;
     unsigned int color;
+    unsigned int length;
     bool operator;
 };
 


### PR DESCRIPTION
Add check for syntax_on being true and current_syntax not being null before printing syntax name