### PR TITLE
Optimize syntaxHighlight for default_syntax and remove unnecessary calls

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -1,6 +1,12 @@
 #include "ted.h"
 
 void syntaxHighlight(void) {
+    if (config.current_syntax == &default_syntax) {// just reset color to all visible lines
+        for (unsigned int at = text_scroll.y; (at < text_scroll.y + config.lines) && (at != num_lines); ++at)
+            memset(lines[at].color, 0, lines[at].length * sizeof(*lines[at].color));
+        return;
+    }
+
     bool multi_line_comment = 0;
     bool backslash = 0;
     char string = '\0';
@@ -22,7 +28,7 @@ void syntaxHighlight(void) {
         memset(lines[at].color, 0, (lines[at].length + 1) * sizeof(*lines[at].color));
         for (unsigned int i = 0; i <= lines[at].length; i++) {
             if (lines[at].data[i] == '\\') {
-                lines[at].color[i] = string ? config.current_syntax->syntax_string_color : 0x0;
+                lines[at].color[i] = string ? config.current_syntax->syntax_string_color : 0;
                 backslash = !backslash;
                 continue;
             }

--- a/src/color.c
+++ b/src/color.c
@@ -3,7 +3,7 @@
 void syntaxHighlight(void) {
     if (config.current_syntax == &default_syntax) {// just reset color to all visible lines
         for (unsigned int at = text_scroll.y; (at < text_scroll.y + config.lines) && (at != num_lines); ++at)
-            memset(lines[at].color, 0, lines[at].length * sizeof(*lines[at].color));
+            memset(lines[at].color, 0, (lines[at].length + 1) * sizeof(*lines[at].color));
         return;
     }
 
@@ -20,10 +20,10 @@ void syntaxHighlight(void) {
     unsigned int octprefixlen = strlen(config.current_syntax->number_prefix[1]);
     unsigned int binprefixlen = strlen(config.current_syntax->number_prefix[2]);
 
-    unsigned int sytnax_start = strlen(config.current_syntax->stringchars) || mlinecommentstart || mlinecommentend ? 0 : text_scroll.y;
-    unsigned int sytnax_end = text_scroll.y + config.lines;
+    unsigned int syntax_start = strlen(config.current_syntax->stringchars) || mlinecommentstart || mlinecommentend ? 0 : text_scroll.y;
+    unsigned int syntax_end = text_scroll.y + config.lines;
 
-    for (unsigned int at = sytnax_start; (at < sytnax_end) && (at != num_lines); ++at) {
+    for (unsigned int at = syntax_start; (at < syntax_end) && (at != num_lines); ++at) {
         bool comment = 0;
         memset(lines[at].color, 0, (lines[at].length + 1) * sizeof(*lines[at].color));
         for (unsigned int i = 0; i <= lines[at].length; i++) {

--- a/src/config_dialog.c
+++ b/src/config_dialog.c
@@ -97,6 +97,7 @@ static void syntax(char **words, unsigned int words_len) {
         free(str);
     } else
         config.current_syntax = &default_syntax;
+    syntaxHighlight();
 }
 
 static void read_only_cmd(char **words, unsigned int words_len) {

--- a/src/extension.c
+++ b/src/extension.c
@@ -22,7 +22,7 @@ bool detect_extension(char *fname) {
         }
     }
     
-  END:
+END:
     config.current_syntax = &default_syntax;
     return false; // Not found
 }

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -5,7 +5,6 @@ void expandLine(unsigned int at, int x) {
         lines[at].len += READ_BLOCKSIZE;
         lines[at].data = realloc(lines[cy].data, lines[cy].len * sizeof(uchar32_t));
         lines[at].color = realloc(lines[cy].color, lines[cy].len * sizeof(unsigned char));
-        syntaxHighlight();
     }
 }
 
@@ -38,6 +37,7 @@ void process_keypress(int c) {
         cursor.x = last_cursor_x;
 
         cursor_in_valid_position();
+        syntaxHighlight();
         break;
     case KEY_DOWN:
     case ctrl('n'):
@@ -45,6 +45,7 @@ void process_keypress(int c) {
         cursor.x = last_cursor_x;
 
         cursor_in_valid_position();
+        syntaxHighlight();
         break;
     case KEY_LEFT:
     case ctrl('b'):
@@ -233,10 +234,10 @@ void process_keypress(int c) {
 
                 for (unsigned int i = 0; i < ident; i++)
                     process_keypress(KEY_RIGHT);
+
+                syntaxHighlight();
             } else
                 lines[cy].ident = 0;
-
-            syntaxHighlight();
         }
         break;
     }
@@ -264,6 +265,7 @@ void process_keypress(int c) {
 
         if (add_char(cx, cy, ec))
             process_keypress(KEY_RIGHT);
-    }
 
+        syntaxHighlight();
+    }
 }

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -175,17 +175,14 @@ void process_keypress(int c) {
                     process_keypress(KEY_LEFT);
             } else if (cy > 0) {
                 struct LINE del_line = lines[cy];
-
                 memmove(&lines[cy], &lines[cy + 1], (num_lines - cy - 1) * sizeof(struct LINE));
-
                 lines = realloc(lines, --num_lines * sizeof(struct LINE));
 
-                process_keypress(KEY_UP);
-
+                cursor.y -= cursor.y > 0;
                 cursor.x = lines[cy].length;
+                cursor_in_valid_position();
 
                 process_keypress(KEY_RIGHT);
-
                 expandLine(cy, del_line.length);
 
                 memmove(&lines[cy].data[lines[cy].length], del_line.data, del_line.length * sizeof(uchar32_t));
@@ -215,9 +212,10 @@ void process_keypress(int c) {
             num_lines++;
 
             unsigned int lcx = cx;
-            cursor.x = 0;
             last_cursor_x = 0;
-            process_keypress(KEY_DOWN);
+            cursor.y++;
+            cursor.x = 0;
+            cursor_in_valid_position();
             new_line(cy, lcx);
 
             if (config.autotab == 1) {
@@ -234,10 +232,10 @@ void process_keypress(int c) {
 
                 for (unsigned int i = 0; i < ident; i++)
                     process_keypress(KEY_RIGHT);
-
-                syntaxHighlight();
             } else
                 lines[cy].ident = 0;
+
+            syntaxHighlight();
         }
         break;
     }

--- a/src/modify.c
+++ b/src/modify.c
@@ -15,7 +15,6 @@ bool add_char(int x, int y, uchar32_t c) {
         memmove(&lines[y].data[x + 1], &lines[y].data[x], (lines[y].length - x) * sizeof(uchar32_t));
         lines[y].data[x] = c;
         lines[y].data[++lines[y].length] = '\0';
-        syntaxHighlight();
         return 1;
     }
     return 0;

--- a/src/open_and_save.c
+++ b/src/open_and_save.c
@@ -20,7 +20,6 @@ void savefile(void) {
         lines[ln].length = 0;
         lines[ln].ident = 0;
         *lines[ln].data = '\0';
-        syntaxHighlight();
     }
     
     for (unsigned int i = 0; i < num_lines; i++) {
@@ -53,8 +52,6 @@ void read_lines(void) {
         lines[0].length = 0;
         lines[0].data[0] = '\0';
         lines[0].ident = 0;
-        
-        syntaxHighlight();
         return;
     }
 

--- a/src/ted.c
+++ b/src/ted.c
@@ -86,14 +86,13 @@ int main(int argc, char **argv) {
     }
 
     config.lines = LINES - 1;
+    int last_LINES = LINES;
+    int last_COLS = COLS;
 
     fp = fopen(filename, "r");
     read_lines();
     if (fp) fclose(fp);
     detect_read_only(filename);
-    
-    int last_LINES = LINES;
-    int last_COLS = COLS;
     
     int c;
     while (1) {
@@ -121,11 +120,8 @@ int main(int argc, char **argv) {
             } else
                 break;
         }
-
         process_keypress(c);
-        syntaxHighlight();
     }
-
 
     // TODO: add free_everything function
     free_lines();


### PR DESCRIPTION
Create a special optimization for default_syntax  in syntaxHighlight (note that this is only valid as long as default_syntax  is empty) that just zeroes all visible lines without checking for string/comment/etc.
Also remove some unnecessary/redundant calls to syntaxHighlight (even the one in the main loop) by trying to cover all possible cases in which syntaxHighlight should be called, but not when it should have not effect, like when a blank line is added.