### PR TITLE
Highly optimize syntaxHighlight

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -16,9 +16,10 @@ void init_syntax_state(struct SHSTATE *state, struct SHD *syntax) {
 
 int syntaxHighlight(void) {
     if (config.current_syntax == &default_syntax) {// just reset color to all lines
-        for (unsigned int at = 0; at < num_lines; at++) {
+        for (unsigned int at = config.selected_buf.syntax_state.at_line; at < num_lines; at++) {
             if (syntax_yield) {
                 syntax_yield = 0;
+                config.selected_buf.syntax_state.at_line = at;
                 return SYNTAX_TODO;
             }
             memset(lines[at].color, 0, (lines[at].length + 1) * sizeof(*lines[at].color));

--- a/src/color.c
+++ b/src/color.c
@@ -36,6 +36,10 @@ void syntaxHighlight(void) {
     unsigned int octprefixlen = config.selected_buf.syntax_state.octprefixlen;
     unsigned int binprefixlen = config.selected_buf.syntax_state.binprefixlen;
 
+    struct itimerval interval = {0}, zeroed = {0};// set preemptive timer
+    interval.it_value.tv_usec = SYNTAX_TIMEOUT;
+    setitimer(ITIMER_REAL, &interval, NULL);
+
     for (unsigned int at = config.selected_buf.syntax_state.at_line; at < num_lines; at++) {
         if (syntax_yield) {//save state
             config.selected_buf.syntax_state.multi_line_comment = multi_line_comment;
@@ -232,6 +236,7 @@ void syntaxHighlight(void) {
         }
     }
 END:
+    setitimer(ITIMER_REAL, &zeroed, NULL);
     syntax_yield = 0;
     longjmp(syntax_env, SYNTAX_END);
 }

--- a/src/color.c
+++ b/src/color.c
@@ -14,12 +14,12 @@ void init_syntax_state(struct SHSTATE *state, struct SHD *syntax) {
     state->at_line = 0;
 }
 
-void syntaxHighlight(void) {
+int syntaxHighlight(void) {
     if (config.current_syntax == &default_syntax) {// just reset color to all lines
         for (unsigned int at = 0; at < num_lines; at++) {
             if (syntax_yield) {
                 syntax_yield = 0;
-                longjmp(syntax_env, SYNTAX_TODO);
+                return SYNTAX_TODO;
             }
             memset(lines[at].color, 0, (lines[at].length + 1) * sizeof(*lines[at].color));
         }
@@ -54,7 +54,7 @@ void syntaxHighlight(void) {
             config.selected_buf.syntax_state.binprefixlen = binprefixlen;
             config.selected_buf.syntax_state.at_line = at;
             syntax_yield = 0;
-            longjmp(syntax_env, SYNTAX_TODO);
+            return SYNTAX_TODO;
         }
 
         bool comment = 0;
@@ -238,7 +238,7 @@ void syntaxHighlight(void) {
 END:
     setitimer(ITIMER_REAL, &zeroed, NULL);
     syntax_yield = 0;
-    longjmp(syntax_env, SYNTAX_END);
+    return SYNTAX_END;
 }
 
 void readColor(unsigned int at, unsigned int at1, unsigned char *fg, unsigned char *bg) {

--- a/src/config_dialog.c
+++ b/src/config_dialog.c
@@ -97,7 +97,8 @@ static void syntax(char **words, unsigned int words_len) {
         free(str);
     } else
         config.current_syntax = &default_syntax;
-    syntaxHighlight();
+    
+    syntax_change = 1; // signal change to syntaxHighlight
 }
 
 static void read_only(char **words, unsigned int words_len) {

--- a/src/cursor_in_valid_position.c
+++ b/src/cursor_in_valid_position.c
@@ -21,6 +21,8 @@ void cursor_in_valid_position(void) {
         text_scroll.x = cursor.x;
     else if (cursor.x > text_scroll.x + (COLS - len_line_number - 3))
         text_scroll.x = cursor.x - (COLS - len_line_number - 3);
+        
+    syntax_change = 1;
 }
 
 // This should be an inline function
@@ -29,3 +31,4 @@ void change_position(unsigned int x, unsigned int y) {
     cursor.x = x;
     cursor_in_valid_position();
 }
+

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -278,3 +278,4 @@ void process_keypress(int c) {
         syntax_change = 1; // signal change to syntaxHighlight
     }
 }
+

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -115,7 +115,8 @@ void process_keypress(int c) {
             }
             cursor_in_valid_position();
             calculate_len_line_number();
-            syntaxHighlight();
+
+            syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
     } case ctrl('w'):
@@ -128,7 +129,8 @@ void process_keypress(int c) {
             if (cx > 0 && !strchr(config.current_syntax->word_separators, lines[cy].data[cx - 1]))
                 passed_spaces = 1;
         }
-        syntaxHighlight();
+        
+        syntax_change = 1; // signal change to syntaxHighlight
         break;
     } case ctrl('o'):
     {
@@ -195,7 +197,7 @@ void process_keypress(int c) {
                 if (lines[cy].data[i] != ' ') break;
                 lines[cy].ident++;
             }
-            syntaxHighlight();
+            syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
     } case '\n': case KEY_ENTER: case '\r':
@@ -229,7 +231,7 @@ void process_keypress(int c) {
             } else
                 lines[cy].ident = 0;
 
-            syntaxHighlight();
+            syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
     }
@@ -273,8 +275,6 @@ void process_keypress(int c) {
                 else break;
             }
         }
-
-        syntaxHighlight();
+        syntax_change = 1; // signal change to syntaxHighlight
     }
 }
-

--- a/src/open_and_save.c
+++ b/src/open_and_save.c
@@ -40,7 +40,6 @@ void read_lines(void) {
     if (fp == NULL) {
         num_lines = 1;
         lines = malloc(num_lines * sizeof(*lines));
-
         lines[0] = blank_line();
         return;
     }

--- a/src/open_and_save.c
+++ b/src/open_and_save.c
@@ -88,7 +88,6 @@ void read_lines(void) {
             fgetc(fp);
     }
     detect_extension(filename);
-    syntaxHighlight();
 }
 
 void detect_linebreak(void) {
@@ -134,6 +133,7 @@ void openFile(char *fname, bool needs_to_free) {
 
     calculate_len_line_number();
     detect_read_only(fname);
+    syntax_change = 1; // signal change to syntaxHighlight
 }
 
 void detect_read_only(char *fname) {

--- a/src/show.c
+++ b/src/show.c
@@ -87,7 +87,7 @@ void show_lines(void) {
             readColor(i, text_scroll.x + j, &fg, &bg);
 
             int palette[] = {
-                -1, COLOR_RED, COLOR_GREEN, COLOR_YELLOW, COLOR_BLUE, COLOR_MAGENTA, COLOR_CYAN,// base colors
+                -1, -1, -1, COLOR_RED, COLOR_GREEN, COLOR_YELLOW, COLOR_BLUE, COLOR_MAGENTA, COLOR_CYAN,// base colors
                 COLOR_BLACK, COLOR_RED, COLOR_GREEN, COLOR_YELLOW, COLOR_BLUE, COLOR_MAGENTA, COLOR_CYAN,// bright colors
             };
             
@@ -103,7 +103,7 @@ void show_lines(void) {
 
             if (j + text_scroll.x == cursor.x && i == cursor.y)
                 attron(A_REVERSE);
-            else if (fg > 6)
+            else if (fg > 8)
                 attron(A_BOLD);
             
             if (el == '\t') {
@@ -125,7 +125,7 @@ void show_lines(void) {
             
             if (j == cursor.x + text_scroll.x && i == cursor.y)
                 attroff(A_REVERSE);
-            else if (fg > 6)
+            else if (fg > 8)
                 attroff(A_BOLD);
 
             if (bg)

--- a/src/syntax.h
+++ b/src/syntax.h
@@ -11,19 +11,19 @@
 
 // to keep update with palette in show_lines
 #define PALETTE_OFF             0
-#define PALETTE_RED             1
-#define PALETTE_GREEN           2
-#define PALETTE_YELLOW          3
-#define PALETTE_BLUE            4
-#define PALETTE_MAGENTA         5
-#define PALETTE_CYAN            6
-#define PALETTE_GRAY            7
-#define PALETTE_BRIGHT_RED      8
-#define PALETTE_BRIGHT_GREEN    9
-#define PALETTE_BRIGHT_YELLOW   10
-#define PALETTE_BRIGHT_BLUE     11
-#define PALETTE_BRIGHT_MAGENTA  12
-#define PALETTE_BRIGHT_CYAN     13
+#define PALETTE_RED             3
+#define PALETTE_GREEN           4
+#define PALETTE_YELLOW          5
+#define PALETTE_BLUE            6
+#define PALETTE_MAGENTA         7
+#define PALETTE_CYAN            8
+#define PALETTE_GRAY            9
+#define PALETTE_BRIGHT_RED      10
+#define PALETTE_BRIGHT_GREEN    11
+#define PALETTE_BRIGHT_YELLOW   12
+#define PALETTE_BRIGHT_BLUE     13
+#define PALETTE_BRIGHT_MAGENTA  14
+#define PALETTE_BRIGHT_CYAN     15
 
 extern struct SHD *syntaxes[];
 

--- a/src/ted.c
+++ b/src/ted.c
@@ -149,3 +149,4 @@ int main(int argc, char **argv) {
     endwin();
     return 0;
 }
+

--- a/src/ted.h
+++ b/src/ted.h
@@ -239,3 +239,4 @@ extern sig_atomic_t syntax_yield;
 extern bool syntax_change;
 
 #endif
+

--- a/src/ted.h
+++ b/src/ted.h
@@ -34,8 +34,8 @@
 #define SYNTAX_END  -1  // syntaxHighlight highlighted all the file
 #define SYNTAX_TODO -2  // syntaxHighlight didn't finish yet
 
-#define INPUT_TIMEOUT   10    //timeout for input in ncurses (in milliseconds)
-#define SYNTAX_TIMEOUT  25000 //time slice in which syntaxHighlight runs (in microseconds) (25 milliseconds)
+#define INPUT_TIMEOUT  5     //timeout for input in ncurses (in milliseconds)
+#define SYNTAX_TIMEOUT 30000 //time slice in which syntaxHighlight runs (in microseconds) (30 milliseconds)
 
 typedef uint32_t uchar32_t;
 

--- a/src/ted.h
+++ b/src/ted.h
@@ -11,9 +11,12 @@
 #include <unistd.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/time.h>
 #include <errno.h>
 #include <stdint.h>
 #include <unistd.h>
+#include <signal.h>
+#include <setjmp.h>
 
 #define READ_BLOCKSIZE 100
 #define ctrl(x) ((x) & 0x1f)
@@ -27,6 +30,12 @@
 
 #define IN_RANGE(x, min, max)   ((x) >= (min)) && ((x) <= (max))
 #define OUT_RANGE(x, min, max)  ((x) < (min)) || ((x) > (max))
+
+#define SYNTAX_END  -1  // syntaxHighlight highlighted all the file
+#define SYNTAX_TODO -2  // syntaxHighlight didn't finish yet
+
+#define INPUT_TIMEOUT   10    //timeout for input in ncurses (in milliseconds)
+#define SYNTAX_TIMEOUT  25000 //time slice in which syntaxHighlight runs (in microseconds) (25 milliseconds)
 
 typedef uint32_t uchar32_t;
 
@@ -142,10 +151,28 @@ struct SHD {
     const char *number_strings[4]; // 0: hexadecimal 1: octal 2: binary 3: decimal
 };
 
+// syntaxHighlight state
+struct SHSTATE {
+    bool multi_line_comment;
+    bool backslash;
+    char string;
+    unsigned int waiting_to_close;
+    unsigned int slinecommentlen;
+    unsigned int mlinecommentstart;
+    unsigned int mlinecommentend;
+    unsigned int hexprefixlen;
+    unsigned int octprefixlen;
+    unsigned int binprefixlen;
+    unsigned int at_line;
+};
+
+void init_syntax_state(struct SHSTATE *state, struct SHD *syntax);
+
 struct BUFFER {
     bool modified;
     bool read_only;
     bool can_write;
+    struct SHSTATE syntax_state;
 };
 
 struct CFG {
@@ -210,5 +237,8 @@ extern char *menu_message;
 extern struct SHD default_syntax;
 extern const uchar32_t substitute_char;
 extern const char *substitute_string;
+extern sig_atomic_t syntax_yield;
+extern bool syntax_change;
+extern jmp_buf syntax_env;
 
 #endif

--- a/src/ted.h
+++ b/src/ted.h
@@ -211,7 +211,6 @@ struct LINE {
 };
 
 
-
 struct CURSOR {
     unsigned int x;
     unsigned int y;

--- a/src/ted.h
+++ b/src/ted.h
@@ -16,7 +16,6 @@
 #include <stdint.h>
 #include <unistd.h>
 #include <signal.h>
-#include <setjmp.h>
 
 #define READ_BLOCKSIZE 100
 #define ctrl(x) ((x) & 0x1f)
@@ -89,7 +88,7 @@ int utf8ToMultibyte(uchar32_t c, unsigned char *out, bool validate);
 bool validate_utf8(unsigned char *ucs);
 
 // color.c
-void syntaxHighlight(void);
+int syntaxHighlight(void);
 void readColor(unsigned int at, unsigned int at1, unsigned char *fg, unsigned char *bg);
 
 // utils.c
@@ -238,6 +237,5 @@ extern const uchar32_t substitute_char;
 extern const char *substitute_string;
 extern sig_atomic_t syntax_yield;
 extern bool syntax_change;
-extern jmp_buf syntax_env;
 
 #endif

--- a/src/utils.c
+++ b/src/utils.c
@@ -104,12 +104,11 @@ struct LINE blank_line(void) {
 
     ln.len = READ_BLOCKSIZE;
     ln.data = malloc(ln.len * sizeof(*ln.data));
-    ln.color = malloc(ln.len * sizeof(*ln.color));
+    ln.color = calloc(ln.len, sizeof(*ln.color));
     ln.length = 0;
     ln.ident = 0;
     ln.multiline_comment = 0;
 
     *ln.data = '\0';
-
     return ln;
 }


### PR DESCRIPTION
Currently syntaxHighlight is a fully synchronous function that takes a lot of time to run on very large file, that are unusably slow to modify/load/update. The aim of this pr is to transform syntaxHighlight from a heavy blocking function to a asynchron-ish function that is executed cooperatively with the main loop while no input from the user is available.

## how it works
Change the way the main loop and syntaxHighlight interacts. Now syntaxHighlight is preemptively interrupted and it is not a blocking function anymore, behaving more similarly to a coroutine/asynchronous function than a normal one. When syntaxHighlight is called it start a timer that after `SYNTAX_TIMEOUT` microseconds sends a `SIGALRM` that sets the flag `syntax_yield` to true through a signal handler, when `syntax_yield` is set syntaxHighlight will save its state in a struct SHSTATE and return. Every subsequent call to syntaxHighlight  will restore the saved context and continue, and when the highlighting is done syntaxHighlight will return `SYNTAX_END`  (when yielding syntaxHighlight returns `SYNTAX_TODO`). Note that syntaxHighlight  always returns either a `SYNTAX_END`  or `SYNTAX_TODO` ~~with a `longjmp` to the main loop~~. 

If the syntax needs to be updated (opened a new file, changed syntax descriptor, etc) the flag `syntax_change` is set and the main loop will automatically prepare and call `syntaxHighlight`.
~~`syntax_env` is the `setjmp` buffer used to jump between syntaxHighlight and the main loop.~~

## notes
* I don't know why, but when compiling with asan this is much slower than with the normal compilation flags.

* When syntaxHighlight hasn't yet highlighted a line, that line will be shown as white to the user. (a white line is better than having to wait for it to finish the entire file without handling any input). 

* ncurses is not set in nonblocking mode with a timeout of `INPUT_TIMEOUT`.

## references
This helped me to come up with this solution: http://enki-editor.org/2014/08/22/Syntax_highlighting.html
Other useful links:
* https://www.gnu.org/software/libc/manual/html_node/Setting-an-Alarm.html
* http://man.docs.sk/3ncurses/raw.html
