### PR TITLE
Store syntax state on every line

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ debug:  src/*.c
 	$(CC) -o ted $^ $(CFLAGS) $(LIBS) -g3
 
 asan: src/*.c
-	$(CC) -o ted $^ $(CFLAGS) $(LIBS) -fsanitize=address
+	$(CC) -o ted $^ $(CFLAGS) $(LIBS) -fsanitize=address -g
 
 clean:
 	rm ted -f

--- a/src/color.c
+++ b/src/color.c
@@ -36,10 +36,8 @@ int syntaxHighlight(void) {
             return SYNTAX_TODO;
         }
         // restore multiline state consistent with the previous line
-        lines[at].state.multi_line_comment = lines[at - (at > 0)].state.multi_line_comment;
-        lines[at].state.string = lines[at - (at > 0)].state.string;
-        lines[at].state.backslash = lines[at - (at > 0)].state.backslash;
-        lines[at].state.waiting_to_close = lines[at - (at > 0)].state.waiting_to_close;
+        if (at == 0) memset(&lines[at].state, 0, sizeof(lines[at].state));
+        else memcpy(&lines[at].state, &lines[at - 1].state, sizeof(lines[at].state));
 
         memset(lines[at].color, 0, (lines[at].length + 1) * sizeof(*lines[at].color));
         bool comment = 0;
@@ -219,11 +217,11 @@ int syntaxHighlight(void) {
             }
         }
         
-        if (syntax_update_fast && at > config.selected_buf.syntax_at && //highlight at least one line
-            (lines[at].state.backslash == lines[at + (at < num_lines)].state.backslash &&
-            lines[at].state.multi_line_comment == lines[at + (at < num_lines)].state.multi_line_comment &&
-            lines[at].state.string == lines[at + (at < num_lines)].state.string &&
-            lines[at].state.waiting_to_close == lines[at + (at < num_lines)].state.waiting_to_close)) {
+        if (syntax_update_fast && (at > config.selected_buf.syntax_at && at > 0) && //highlight at least one line
+            (lines[at].state.backslash == lines[at + ((at + 1) < num_lines)].state.backslash &&
+            lines[at].state.multi_line_comment == lines[at + ((at + 1) < num_lines)].state.multi_line_comment &&
+            lines[at].state.string == lines[at + ((at + 1) < num_lines)].state.string &&
+            lines[at].state.waiting_to_close == lines[at + ((at + 1) < num_lines)].state.waiting_to_close)) {
             syntax_update_fast = 0;
             goto END;
         }

--- a/src/color.c
+++ b/src/color.c
@@ -5,23 +5,6 @@ void set_syntax_change(unsigned int at, bool update_fast) {
     syntax_change = 1, syntax_update_fast = update_fast;// signal change to syntaxHighlight
 }
 
-void reset_brackets(void) {
-    for (unsigned int i = 0; i < config.selected_buf.brackets_len; i++) {
-        struct CURSOR pos = config.selected_buf.highlighted_brackets[i];
-        lines[pos.y].color[pos.x] = config.current_syntax->match_color;
-    }
-
-    config.selected_buf.brackets_len = 0;
-    free(config.selected_buf.highlighted_brackets);
-    config.selected_buf.highlighted_brackets = NULL;
-}
-
-void add_highlighted_bracket(unsigned int at, unsigned int x) {
-    config.selected_buf.highlighted_brackets = realloc(config.selected_buf.highlighted_brackets, ++config.selected_buf.brackets_len * sizeof(struct CURSOR));
-    config.selected_buf.highlighted_brackets[config.selected_buf.brackets_len - 1].y = at;
-    config.selected_buf.highlighted_brackets[config.selected_buf.brackets_len - 1].x = x;
-}
-
 int syntaxHighlight(void) {
     struct itimerval interval = {0}, zeroed = {0};// set preemptive timer
     interval.it_value.tv_usec = SYNTAX_TIMEOUT;
@@ -129,10 +112,8 @@ int syntaxHighlight(void) {
 
             if (lines[at].data[i] && (opening || closing)) {
                 if (lines[at].state.waiting_to_close && !opening) {
-                    if (lines[at].state.waiting_to_close == 1) {
+                    if (lines[at].state.waiting_to_close == 1)
                         lines[at].color[i] = config.current_syntax->hover_match_color;
-                        add_highlighted_bracket(at, i);
-                    }
                     lines[at].state.waiting_to_close--;
                     continue;
                 } else if (lines[at].state.waiting_to_close && opening)
@@ -140,7 +121,6 @@ int syntaxHighlight(void) {
                 
                 if (at == cursor.y && (i + 1) == cursor.x) {
                     lines[at].color[i] = config.current_syntax->hover_match_color;
-                    add_highlighted_bracket(at, i);
 
                     if (opening) {
                         lines[at].state.waiting_to_close = 1;
@@ -151,7 +131,6 @@ int syntaxHighlight(void) {
                                 if (strchr(config.current_syntax->match[0], lines[_at].data[_i])) {
                                     lay--;
                                     if (lay == 1) {
-                                        add_highlighted_bracket(at, i);
                                         lines[_at].color[_i] = config.current_syntax->hover_match_color;
                                         _at = -1;
                                         break;

--- a/src/color.c
+++ b/src/color.c
@@ -112,8 +112,10 @@ int syntaxHighlight(void) {
 
             if (lines[at].data[i] && (opening || closing)) {
                 if (lines[at].state.waiting_to_close && !opening) {
-                    if (lines[at].state.waiting_to_close == 1)
+                    if (lines[at].state.waiting_to_close == 1) {
                         lines[at].color[i] = config.current_syntax->hover_match_color;
+                        syntax_matched = 1;
+                    }
                     lines[at].state.waiting_to_close--;
                     continue;
                 } else if (lines[at].state.waiting_to_close && opening)
@@ -121,6 +123,7 @@ int syntaxHighlight(void) {
                 
                 if (at == cursor.y && (i + 1) == cursor.x) {
                     lines[at].color[i] = config.current_syntax->hover_match_color;
+                    syntax_matched = 1;
 
                     if (opening) {
                         lines[at].state.waiting_to_close = 1;

--- a/src/color.c
+++ b/src/color.c
@@ -1,5 +1,10 @@
 #include "ted.h"
 
+void set_syntax_change(unsigned int at) {
+    config.selected_buf.syntax_at = at; // update from current position
+    syntax_change = 1, syntax_update_fast = 1;// signal change to syntaxHighlight
+}
+
 int syntaxHighlight(void) {
     struct itimerval interval = {0}, zeroed = {0};// set preemptive timer
     interval.it_value.tv_usec = SYNTAX_TIMEOUT;

--- a/src/color.c
+++ b/src/color.c
@@ -9,7 +9,7 @@ int syntaxHighlight(void) {
         for (unsigned int at = config.selected_buf.syntax_at; at < num_lines; at++) {
             if (syntax_yield) {
                 syntax_yield = 0;
-                config.selected_buf.syntax_at = at;
+                config.selected_buf.syntax_at = at - (at > 0);
                 return SYNTAX_TODO;
             }
             memset(lines[at].color, 0, (lines[at].length + 1) * sizeof(*lines[at].color));
@@ -26,7 +26,7 @@ int syntaxHighlight(void) {
     for (unsigned int at = config.selected_buf.syntax_at; at < num_lines; at++) {
         memset(&lines[at].state, 0, sizeof(lines[at].state)); //reset the state of the line we are updating
         if (syntax_yield) {//save state
-            config.selected_buf.syntax_at = at - at > 0;
+            config.selected_buf.syntax_at = at - (at > 0);
             syntax_yield = 0;
             return SYNTAX_TODO;
         }

--- a/src/color.c
+++ b/src/color.c
@@ -13,6 +13,7 @@ int syntaxHighlight(void) {
                 return SYNTAX_TODO;
             }
             memset(lines[at].color, 0, (lines[at].length + 1) * sizeof(*lines[at].color));
+            memset(&lines[at].state, 0, sizeof(lines[at].state));
         }
         goto END;
     }

--- a/src/config_dialog.c
+++ b/src/config_dialog.c
@@ -98,12 +98,11 @@ static void syntax(char **words, unsigned int words_len) {
     } else
         config.current_syntax = &default_syntax;
     
-    memset(&lines[0].state, 0, sizeof(lines[0].state)); // reset first line state
     for (unsigned int at = 0; at < num_lines; at++) // reset to white all lines
         memset(lines[at].color, 0, (lines[at].length + 1) * sizeof(*lines[at].color));
 
-    config.selected_buf.syntax_at = 0;
-    syntax_change = 1;
+    memset(&lines[0].state, 0, sizeof(lines[0].state)); // reset first line state
+    set_syntax_change(0, 0);
 }
 
 static void read_only(char **words, unsigned int words_len) {

--- a/src/config_dialog.c
+++ b/src/config_dialog.c
@@ -98,7 +98,12 @@ static void syntax(char **words, unsigned int words_len) {
     } else
         config.current_syntax = &default_syntax;
     
-    syntax_change = 1; // signal change to syntaxHighlight
+    memset(&lines[0].state, 0, sizeof(lines[0].state)); // reset first line state
+    for (unsigned int at = 0; at < num_lines; at++) // reset to white all lines
+        memset(lines[at].color, 0, (lines[at].length + 1) * sizeof(*lines[at].color));
+
+    config.selected_buf.syntax_at = 0;
+    syntax_change = 1;
 }
 
 static void read_only(char **words, unsigned int words_len) {

--- a/src/cursor_in_valid_position.c
+++ b/src/cursor_in_valid_position.c
@@ -22,7 +22,10 @@ void cursor_in_valid_position(void) {
     else if (cursor.x > text_scroll.x + (COLS - len_line_number - 3))
         text_scroll.x = cursor.x - (COLS - len_line_number - 3);
 
-    syntax_change = 1, syntax_update_fast = 1;
+    if (cx != 0 && config.current_syntax != &default_syntax) {
+        reset_brackets();
+        set_syntax_change(cy, 0);
+    }
 }
 
 // This should be an inline function

--- a/src/cursor_in_valid_position.c
+++ b/src/cursor_in_valid_position.c
@@ -21,6 +21,8 @@ void cursor_in_valid_position(void) {
         text_scroll.x = cursor.x;
     else if (cursor.x > text_scroll.x + (COLS - len_line_number - 3))
         text_scroll.x = cursor.x - (COLS - len_line_number - 3);
+
+    syntax_change = 1, syntax_update_fast = 1;
 }
 
 // This should be an inline function

--- a/src/cursor_in_valid_position.c
+++ b/src/cursor_in_valid_position.c
@@ -22,9 +22,9 @@ void cursor_in_valid_position(void) {
     else if (cursor.x > text_scroll.x + (COLS - len_line_number - 3))
         text_scroll.x = cursor.x - (COLS - len_line_number - 3);
 
-    if (cx != 0 && config.current_syntax != &default_syntax) {
-        reset_brackets();
-        set_syntax_change(cy, 0);
+    if (config.current_syntax != &default_syntax &&
+        (strchr(config.current_syntax->match[0], lines[cy].data[cx]) || strchr(config.current_syntax->match[1], lines[cy].data[cx]))) {
+        set_syntax_change(0, 0);// just reset syntax highlighting
     }
 }
 

--- a/src/cursor_in_valid_position.c
+++ b/src/cursor_in_valid_position.c
@@ -22,13 +22,14 @@ void cursor_in_valid_position(void) {
     else if (cursor.x > text_scroll.x + (COLS - len_line_number - 3))
         text_scroll.x = cursor.x - (COLS - len_line_number - 3);
 
-    if (config.current_syntax != &default_syntax &&
-        (strchr(config.current_syntax->match[0], lines[cy].data[cx]) || strchr(config.current_syntax->match[1], lines[cy].data[cx]))) {
-        set_syntax_change(0, 0);// just reset syntax highlighting
+    if (config.current_syntax != &default_syntax && (syntax_matched ||
+        (strchr(config.current_syntax->match[0], lines[cy].data[cx - (cx > 0)]) ||
+        strchr(config.current_syntax->match[1], lines[cy].data[cx - (cx > 0)])))) {
+        syntax_matched = 0;
+        set_syntax_change(0, 0);// reset syntax highlighting state
     }
 }
 
-// This should be an inline function
 void change_position(unsigned int x, unsigned int y) {
     cursor.y = y;
     cursor.x = x;

--- a/src/cursor_in_valid_position.c
+++ b/src/cursor_in_valid_position.c
@@ -21,8 +21,6 @@ void cursor_in_valid_position(void) {
         text_scroll.x = cursor.x;
     else if (cursor.x > text_scroll.x + (COLS - len_line_number - 3))
         text_scroll.x = cursor.x - (COLS - len_line_number - 3);
-        
-    syntax_change = 1;
 }
 
 // This should be an inline function

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -116,6 +116,7 @@ void process_keypress(int c) {
             cursor_in_valid_position();
             calculate_len_line_number();
 
+            config.selected_buf.syntax_at = cy - cy > 0; // update from current position
             syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
@@ -130,6 +131,7 @@ void process_keypress(int c) {
                 passed_spaces = 1;
         }
         
+        config.selected_buf.syntax_at = cy - cy > 0; // update from current position
         syntax_change = 1; // signal change to syntaxHighlight
         break;
     } case ctrl('o'):
@@ -197,6 +199,7 @@ void process_keypress(int c) {
                 if (lines[cy].data[i] != ' ') break;
                 lines[cy].ident++;
             }
+            config.selected_buf.syntax_at = cy - cy > 0; // update from current position
             syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
@@ -231,6 +234,7 @@ void process_keypress(int c) {
             } else
                 lines[cy].ident = 0;
 
+            config.selected_buf.syntax_at = cy - cy > 0; // update from current position
             syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
@@ -238,7 +242,6 @@ void process_keypress(int c) {
     }
 
     if (isprint(c) || c == '\t' || (c >= 0xC0 && c <= 0xDF) || (c >= 0xE0 && c <= 0xEF) || (c >= 0xF0 && c <= 0xF7)) {
-
         if (c == ' ' && cx <= lines[cy].ident)
             lines[cy].ident++;
 
@@ -275,6 +278,7 @@ void process_keypress(int c) {
                 else break;
             }
         }
+        config.selected_buf.syntax_at = cy - cy > 0; // update from current position
         syntax_change = 1; // signal change to syntaxHighlight
     }
 }

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -234,7 +234,7 @@ void process_keypress(int c) {
             } else
                 lines[cy].ident = 0;
 
-            config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
+            config.selected_buf.syntax_at = cy - 1; // update from current position
             syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
@@ -278,7 +278,7 @@ void process_keypress(int c) {
                 else break;
             }
         }
-        config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
+        config.selected_buf.syntax_at = cy; // update from current position
         syntax_change = 1; // signal change to syntaxHighlight
     }
 }

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -116,7 +116,7 @@ void process_keypress(int c) {
             cursor_in_valid_position();
             calculate_len_line_number();
 
-            config.selected_buf.syntax_at = cy - cy > 0; // update from current position
+            config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
             syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
@@ -131,7 +131,7 @@ void process_keypress(int c) {
                 passed_spaces = 1;
         }
         
-        config.selected_buf.syntax_at = cy - cy > 0; // update from current position
+        config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
         syntax_change = 1; // signal change to syntaxHighlight
         break;
     } case ctrl('o'):
@@ -199,7 +199,7 @@ void process_keypress(int c) {
                 if (lines[cy].data[i] != ' ') break;
                 lines[cy].ident++;
             }
-            config.selected_buf.syntax_at = cy - cy > 0; // update from current position
+            config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
             syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
@@ -234,7 +234,7 @@ void process_keypress(int c) {
             } else
                 lines[cy].ident = 0;
 
-            config.selected_buf.syntax_at = cy - cy > 0; // update from current position
+            config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
             syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
@@ -278,7 +278,7 @@ void process_keypress(int c) {
                 else break;
             }
         }
-        config.selected_buf.syntax_at = cy - cy > 0; // update from current position
+        config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
         syntax_change = 1; // signal change to syntaxHighlight
     }
 }

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -116,7 +116,7 @@ void process_keypress(int c) {
             cursor_in_valid_position();
             calculate_len_line_number();
 
-            set_syntax_change(cy- (cy > 0));
+            set_syntax_change(cy- (cy > 0), 1);
         }
         break;
     } case ctrl('w'):
@@ -130,7 +130,7 @@ void process_keypress(int c) {
                 passed_spaces = 1;
         }
         
-        set_syntax_change(cy - (cy > 0));
+        set_syntax_change(cy - (cy > 0), 1);
         break;
     } case ctrl('o'):
     {
@@ -197,7 +197,7 @@ void process_keypress(int c) {
                 if (lines[cy].data[i] != ' ') break;
                 lines[cy].ident++;
             }
-            set_syntax_change(cy - (cy > 0));
+            set_syntax_change(cy - (cy > 0), 1);
         }
         break;
     } case '\n': case KEY_ENTER: case '\r':
@@ -231,7 +231,7 @@ void process_keypress(int c) {
             } else
                 lines[cy].ident = 0;
 
-            set_syntax_change(cy - 1);
+            set_syntax_change(cy - 1, 1);
         }
         break;
     }
@@ -274,7 +274,7 @@ void process_keypress(int c) {
                 else break;
             }
         }
-        set_syntax_change(cy);
+        set_syntax_change(cy, 1);
     }
 }
 

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -117,6 +117,7 @@ void process_keypress(int c) {
             calculate_len_line_number();
 
             config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
+            syntax_update_fast = 1;
             syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
@@ -132,6 +133,7 @@ void process_keypress(int c) {
         }
         
         config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
+        syntax_update_fast = 1;
         syntax_change = 1; // signal change to syntaxHighlight
         break;
     } case ctrl('o'):
@@ -200,6 +202,7 @@ void process_keypress(int c) {
                 lines[cy].ident++;
             }
             config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
+            syntax_update_fast = 1;
             syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
@@ -235,6 +238,7 @@ void process_keypress(int c) {
                 lines[cy].ident = 0;
 
             config.selected_buf.syntax_at = cy - 1; // update from current position
+            syntax_update_fast = 1;
             syntax_change = 1; // signal change to syntaxHighlight
         }
         break;
@@ -279,6 +283,7 @@ void process_keypress(int c) {
             }
         }
         config.selected_buf.syntax_at = cy; // update from current position
+        syntax_update_fast = 1;
         syntax_change = 1; // signal change to syntaxHighlight
     }
 }

--- a/src/keypress.c
+++ b/src/keypress.c
@@ -116,9 +116,7 @@ void process_keypress(int c) {
             cursor_in_valid_position();
             calculate_len_line_number();
 
-            config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
-            syntax_update_fast = 1;
-            syntax_change = 1; // signal change to syntaxHighlight
+            set_syntax_change(cy- (cy > 0));
         }
         break;
     } case ctrl('w'):
@@ -132,9 +130,7 @@ void process_keypress(int c) {
                 passed_spaces = 1;
         }
         
-        config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
-        syntax_update_fast = 1;
-        syntax_change = 1; // signal change to syntaxHighlight
+        set_syntax_change(cy - (cy > 0));
         break;
     } case ctrl('o'):
     {
@@ -201,9 +197,7 @@ void process_keypress(int c) {
                 if (lines[cy].data[i] != ' ') break;
                 lines[cy].ident++;
             }
-            config.selected_buf.syntax_at = cy - (cy > 0); // update from current position
-            syntax_update_fast = 1;
-            syntax_change = 1; // signal change to syntaxHighlight
+            set_syntax_change(cy - (cy > 0));
         }
         break;
     } case '\n': case KEY_ENTER: case '\r':
@@ -237,9 +231,7 @@ void process_keypress(int c) {
             } else
                 lines[cy].ident = 0;
 
-            config.selected_buf.syntax_at = cy - 1; // update from current position
-            syntax_update_fast = 1;
-            syntax_change = 1; // signal change to syntaxHighlight
+            set_syntax_change(cy - 1);
         }
         break;
     }
@@ -282,9 +274,7 @@ void process_keypress(int c) {
                 else break;
             }
         }
-        config.selected_buf.syntax_at = cy; // update from current position
-        syntax_update_fast = 1;
-        syntax_change = 1; // signal change to syntaxHighlight
+        set_syntax_change(cy);
     }
 }
 

--- a/src/open_and_save.c
+++ b/src/open_and_save.c
@@ -132,7 +132,10 @@ void openFile(char *fname, bool needs_to_free) {
 
     calculate_len_line_number();
     detect_read_only(fname);
-    syntax_change = 1; // signal change to syntaxHighlight
+
+    memset(&lines[0].state, 0, sizeof(lines[0].state)); // reset first line state
+    config.selected_buf.syntax_at = 0;
+    syntax_change = 1;
 }
 
 void detect_read_only(char *fname) {

--- a/src/open_and_save.c
+++ b/src/open_and_save.c
@@ -134,8 +134,7 @@ void openFile(char *fname, bool needs_to_free) {
     detect_read_only(fname);
 
     memset(&lines[0].state, 0, sizeof(lines[0].state)); // reset first line state
-    config.selected_buf.syntax_at = 0;
-    syntax_change = 1;
+    set_syntax_change(0, 0);
 }
 
 void detect_read_only(char *fname) {

--- a/src/show.c
+++ b/src/show.c
@@ -82,7 +82,7 @@ void show_lines(void) {
                 continue;
             }
             uchar32_t el = lines[i].data[text_scroll.x + j];
-            
+
             unsigned char fg, bg;
             readColor(i, text_scroll.x + j, &fg, &bg);
 

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -112,9 +112,9 @@ static struct SHD c_syntax = {
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, LITERAL_COLOR, TYPES_COLOR,
     "\"\'", sizeof c_cpp_number_strmatch / sizeof *c_cpp_number_strmatch, c_cpp_number_strmatch,// Strings charaters
-    "//", {"/*", "*/"}, // Comments
+    STRMATCH("//"), {STRMATCH("/*"), STRMATCH("*/")}, // Comments
     {"{[(", "}])"},
-    {"0x", "0", ""},
+    {STRMATCH("0x"), STRMATCH("0"), STRMATCH("")},
     c_cpp_number_suffixes,
     {"0123456789aAbBcCdDeEfF", "01234567", "01", "0123456789"}
 };
@@ -243,9 +243,9 @@ static struct SHD cpp_syntax = {
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, LITERAL_COLOR, TYPES_COLOR,
     "\"\'", sizeof c_cpp_number_strmatch / sizeof *c_cpp_number_strmatch, c_cpp_number_strmatch,// Strings charaters
-    "//", {"/*", "*/"}, // Comments
+    STRMATCH("//"), {STRMATCH("/*"), STRMATCH("*/")}, // Comments
     {"{[(", "}])"},
-    {"0x", "0", "0b"},
+    {STRMATCH("0x"), STRMATCH("0"), STRMATCH("0b")},
     c_cpp_number_suffixes,
     {"0123456789aAbBcCdDeEfF'", "01234567'", "01'", "0123456789'"} // ' is a digit divisor
 };
@@ -356,9 +356,9 @@ static struct SHD python_syntax = {
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, LITERAL_COLOR, TYPES_COLOR,
     "\"\'`", sizeof python_strmatch / sizeof *python_strmatch, python_strmatch,// Strings charaters
-    "#", {"", ""}, // Comments
+    STRMATCH("#"), {STRMATCH(""), STRMATCH("")}, // Comments
     {"{[(", "}])"},
-    {"0x", "0o", "0b"},
+    {STRMATCH("0x"), STRMATCH("0o"), STRMATCH("0b")},
     "jJ",
     {"0123456789aAbBcCdDeEfF_", "01234567_", "01_", "0123456789_"} // _ is a digit divisor
 };
@@ -421,9 +421,9 @@ static struct SHD sh_syntax = {
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, 0, 0,
     "\"\'`", sizeof sh_strmatch / sizeof *sh_strmatch, sh_strmatch, // Strings charaters
-    "#", {"", ""}, // Comments
+    STRMATCH("#"), {STRMATCH(""), STRMATCH("")}, // Comments
     {"{[(", "}])"},
-    {"", "", ""},
+    {STRMATCH(""), STRMATCH(""), STRMATCH("")},
     "",
     {"0123456789aAbBcCdDeEfF", "01234567", "01", "0123456789"}
 };
@@ -522,9 +522,9 @@ static struct SHD rust_syntax = {
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, LITERAL_COLOR, TYPES_COLOR,
     "\"", sizeof rust_strmatch / sizeof *rust_strmatch, rust_strmatch,// Strings charaters
-    "//", {"/*", "*/"}, // Comments
+    STRMATCH("//"), {STRMATCH("/*"), STRMATCH("*/")}, // Comments
     {"{[(", "}])"},
-    {"0x", "0o", "0b"},
+    {STRMATCH("0x"), STRMATCH("0o"), STRMATCH("0b")},
     "uif816324sze",
     {"0123456789aAbBcCdDeEfF_", "01234567_", "01_", "0123456789_"} // _ is a digit divisor
 };
@@ -540,9 +540,9 @@ struct SHD default_syntax = {
     0, NULL,
     0, 0, 0, 0, 0, 0, 0,
     "", 0, NULL,
-    "", {"", ""},
+    STRMATCH(""), {STRMATCH(""), STRMATCH("")},
     {"", ""},
-    {"", "", ""},
+    {STRMATCH(""), STRMATCH(""), STRMATCH("")},
     "",
     {"", "", "", ""}
 };

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -104,7 +104,7 @@ static struct KWD c_kwd[] = {
 static const char *c_exts[] = {"c", "h"};
 
 static struct SHD c_syntax = {
-    "C", 0,
+    "C",
     sizeof c_exts / sizeof *c_exts, c_exts,
     " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?", // Characters that separates words
     sizeof c_kwd / sizeof *c_kwd, c_kwd, //Keywords
@@ -235,7 +235,7 @@ static struct KWD cpp_kwd[] = {
 static const char *cpp_exts[] = {"cpp", "hpp", "cc", "hh"};
 
 static struct SHD cpp_syntax = {
-    "C++", 0,
+    "C++",
     sizeof cpp_exts / sizeof *cpp_exts, cpp_exts,
     " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?", // Characters that separates words
     sizeof cpp_kwd / sizeof *cpp_kwd, cpp_kwd, //Keywords
@@ -348,7 +348,7 @@ static const struct MATCH python_strmatch[] = {
 };
 
 static struct SHD python_syntax = {
-    "Python", 0,
+    "Python",
     sizeof python_exts / sizeof *python_exts, python_exts,
     " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/", // Characters that separates words
     sizeof python_kwd / sizeof *python_kwd, python_kwd, //Keywords
@@ -413,7 +413,7 @@ static const struct MATCH sh_strmatch[] = {
 };
 
 static struct SHD sh_syntax = {
-    "Shell", 0,
+    "Shell",
     sizeof sh_exts / sizeof *sh_exts, sh_exts,
     " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?", // Characters that separates words
     sizeof sh_kwd / sizeof *sh_kwd, sh_kwd, //Keywords
@@ -514,7 +514,7 @@ static const struct MATCH rust_strmatch[] = {
 };
 
 static struct SHD rust_syntax = {
-    "Rust", 0,
+    "Rust",
     sizeof rust_exts / sizeof *rust_exts, rust_exts,
     " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?", // Characters that separates words
     sizeof rust_kwd / sizeof *rust_kwd, rust_kwd, //Keywords
@@ -534,7 +534,7 @@ Default syntax
 */
 
 struct SHD default_syntax = {
-    "Default", 1,
+    "Default",
     0, NULL,
     " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?",
     0, NULL,

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -95,10 +95,6 @@ static struct KWD c_kwd[] = {
     OPERATOR("~", OPERATOR_COLOR), OPERATOR("|", OPERATOR_COLOR), OPERATOR("!", OPERATOR_COLOR),
     OPERATOR("<", OPERATOR_COLOR), OPERATOR(">", OPERATOR_COLOR), OPERATOR("=", OPERATOR_COLOR),
     OPERATOR("?", OPERATOR_COLOR), OPERATOR(":", OPERATOR_COLOR), OPERATOR(".", OPERATOR_COLOR),
-    
-    OPERATOR("(", PAREN_COLOR), OPERATOR(")", PAREN_COLOR),
-    OPERATOR("{", PAREN_COLOR), OPERATOR("}", PAREN_COLOR),
-    OPERATOR("[", PAREN_COLOR), OPERATOR("]", PAREN_COLOR),
 };
 
 static const char *c_exts[] = {"c", "h"};
@@ -108,7 +104,7 @@ static struct SHD c_syntax = {
     sizeof c_exts / sizeof *c_exts, c_exts,
     " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?", // Characters that separates words
     sizeof c_kwd / sizeof *c_kwd, c_kwd, //Keywords
-    LITERAL_COLOR, PALETTE_COLOR(PALETTE_BRIGHT_RED, PALETTE_OFF),
+    PAREN_COLOR, LITERAL_COLOR, PALETTE_COLOR(PALETTE_BRIGHT_RED, PALETTE_OFF),
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, LITERAL_COLOR, TYPES_COLOR,
     "\"\'", sizeof c_cpp_number_strmatch / sizeof *c_cpp_number_strmatch, c_cpp_number_strmatch,// Strings charaters
@@ -226,10 +222,6 @@ static struct KWD cpp_kwd[] = {
     OPERATOR("~", OPERATOR_COLOR), OPERATOR("|", OPERATOR_COLOR), OPERATOR("!", OPERATOR_COLOR),
     OPERATOR("<", OPERATOR_COLOR), OPERATOR(">", OPERATOR_COLOR), OPERATOR("=", OPERATOR_COLOR),
     OPERATOR("?", OPERATOR_COLOR), OPERATOR(":", OPERATOR_COLOR), OPERATOR(".", OPERATOR_COLOR),
-    
-    OPERATOR("(", PAREN_COLOR), OPERATOR(")", PAREN_COLOR),
-    OPERATOR("{", PAREN_COLOR), OPERATOR("}", PAREN_COLOR),
-    OPERATOR("[", PAREN_COLOR), OPERATOR("]", PAREN_COLOR),
 };
 
 static const char *cpp_exts[] = {"cpp", "hpp", "cc", "hh"};
@@ -239,7 +231,7 @@ static struct SHD cpp_syntax = {
     sizeof cpp_exts / sizeof *cpp_exts, cpp_exts,
     " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?", // Characters that separates words
     sizeof cpp_kwd / sizeof *cpp_kwd, cpp_kwd, //Keywords
-    LITERAL_COLOR, PALETTE_COLOR(PALETTE_BRIGHT_RED, PALETTE_OFF),
+    PAREN_COLOR, LITERAL_COLOR, PALETTE_COLOR(PALETTE_BRIGHT_RED, PALETTE_OFF),
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, LITERAL_COLOR, TYPES_COLOR,
     "\"\'", sizeof c_cpp_number_strmatch / sizeof *c_cpp_number_strmatch, c_cpp_number_strmatch,// Strings charaters
@@ -325,10 +317,6 @@ static struct KWD python_kwd[] = {
     OPERATOR("~", OPERATOR_COLOR), OPERATOR("|", OPERATOR_COLOR), OPERATOR("!", OPERATOR_COLOR),
     OPERATOR("<", OPERATOR_COLOR), OPERATOR(">", OPERATOR_COLOR), OPERATOR("=", OPERATOR_COLOR),
     OPERATOR(":", OPERATOR_COLOR), OPERATOR(".", OPERATOR_COLOR), OPERATOR("\\", OPERATOR_COLOR),
-
-    OPERATOR("(", PAREN_COLOR), OPERATOR(")", PAREN_COLOR),
-    OPERATOR("{", PAREN_COLOR), OPERATOR("}", PAREN_COLOR),
-    OPERATOR("[", PAREN_COLOR), OPERATOR("]", PAREN_COLOR)
 };
 
 static const char *python_exts[] = {"py", "py3", "pyx", "pyw", "pyd", "pyde"};
@@ -352,7 +340,7 @@ static struct SHD python_syntax = {
     sizeof python_exts / sizeof *python_exts, python_exts,
     " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/", // Characters that separates words
     sizeof python_kwd / sizeof *python_kwd, python_kwd, //Keywords
-    LITERAL_COLOR, PALETTE_COLOR(PALETTE_BRIGHT_RED, PALETTE_OFF),
+    PAREN_COLOR, LITERAL_COLOR, PALETTE_COLOR(PALETTE_BRIGHT_RED, PALETTE_OFF),
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, LITERAL_COLOR, TYPES_COLOR,
     "\"\'`", sizeof python_strmatch / sizeof *python_strmatch, python_strmatch,// Strings charaters
@@ -400,10 +388,6 @@ static struct KWD sh_kwd[] = {
     OPERATOR("<", OPERATOR_COLOR), OPERATOR(">", OPERATOR_COLOR), OPERATOR("2>", OPERATOR_COLOR),
     OPERATOR("!", OPERATOR_COLOR), OPERATOR("+", OPERATOR_COLOR), OPERATOR("@", OPERATOR_COLOR),
     OPERATOR("*", OPERATOR_COLOR), OPERATOR("-", OPERATOR_COLOR), OPERATOR("?", OPERATOR_COLOR),
-
-    OPERATOR("(", PAREN_COLOR), OPERATOR(")", PAREN_COLOR),
-    OPERATOR("{", PAREN_COLOR), OPERATOR("}", PAREN_COLOR),
-    OPERATOR("[", PAREN_COLOR), OPERATOR("]", PAREN_COLOR),
 };
 
 static const char *sh_exts[] = {"sh", "zsh"};
@@ -417,7 +401,7 @@ static struct SHD sh_syntax = {
     sizeof sh_exts / sizeof *sh_exts, sh_exts,
     " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?", // Characters that separates words
     sizeof sh_kwd / sizeof *sh_kwd, sh_kwd, //Keywords
-    LITERAL_COLOR, PALETTE_COLOR(PALETTE_BRIGHT_RED, PALETTE_OFF),
+    PAREN_COLOR, LITERAL_COLOR, PALETTE_COLOR(PALETTE_BRIGHT_RED, PALETTE_OFF),
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, 0, 0,
     "\"\'`", sizeof sh_strmatch / sizeof *sh_strmatch, sh_strmatch, // Strings charaters
@@ -518,7 +502,7 @@ static struct SHD rust_syntax = {
     sizeof rust_exts / sizeof *rust_exts, rust_exts,
     " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?", // Characters that separates words
     sizeof rust_kwd / sizeof *rust_kwd, rust_kwd, //Keywords
-    LITERAL_COLOR, PALETTE_COLOR(PALETTE_BRIGHT_RED, PALETTE_OFF),
+    PAREN_COLOR, LITERAL_COLOR, PALETTE_COLOR(PALETTE_BRIGHT_RED, PALETTE_OFF),
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, LITERAL_COLOR, TYPES_COLOR,
     "\"", sizeof rust_strmatch / sizeof *rust_strmatch, rust_strmatch,// Strings charaters
@@ -538,7 +522,7 @@ struct SHD default_syntax = {
     0, NULL,
     " \t~!@#$%^&*()-=+[{]}\\|;:'\",.<>/?",
     0, NULL,
-    0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0,
     "", 0, NULL,
     STRMATCH(""), {STRMATCH(""), STRMATCH("")},
     {"", ""},

--- a/src/ted.c
+++ b/src/ted.c
@@ -30,6 +30,7 @@ struct CFG config = {
 
 sig_atomic_t syntax_yield = 0; // flag set by the SIGALRM handler
 bool syntax_change = 0; // used to update syntax highlighting
+bool syntax_update_fast = 0; // update only as little as possible
 
 void sighandler(int x) {
     signal(SIGALRM, sighandler);

--- a/src/ted.c
+++ b/src/ted.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
     detect_read_only(filename);
 
     signal(SIGALRM, sighandler);
-    init_syntax_state(&config.selected_buf.syntax_state, config.current_syntax);
+    init_syntax_state(&config.selected_buf.syntax_state);
     bool syntax_todo = syntaxHighlight() == SYNTAX_TODO;
 
     while (1) {
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
             if (syntax_change) { // reset syntax state before calling syntaxHighlight
                 syntax_change = 0;
                 syntax_yield = 0;
-                init_syntax_state(&config.selected_buf.syntax_state, config.current_syntax);
+                init_syntax_state(&config.selected_buf.syntax_state);
             }
             syntax_todo = syntaxHighlight() == SYNTAX_TODO;
         }

--- a/src/ted.c
+++ b/src/ted.c
@@ -25,7 +25,7 @@ unsigned int last_cursor_x = 0;
 struct CFG config = {
     1, 4, 0, 0, 1, 1, 1, 1,
     &default_syntax, 0, NULL,
-    {0, 0, 1, 0},
+    {0, 0, 1, 0, 0, NULL},
 };
 
 sig_atomic_t syntax_yield = 0; // flag set by the SIGALRM handler

--- a/src/ted.c
+++ b/src/ted.c
@@ -25,7 +25,7 @@ unsigned int last_cursor_x = 0;
 struct CFG config = {
     1, 4, 0, 0, 1, 1, 1, 1,
     &default_syntax, 0, NULL,
-    {0, 0, 1, 0, 0, NULL},
+    {0, 0, 1, 0},
 };
 
 sig_atomic_t syntax_yield = 0; // flag set by the SIGALRM handler

--- a/src/ted.c
+++ b/src/ted.c
@@ -25,11 +25,11 @@ unsigned int last_cursor_x = 0;
 struct CFG config = {
     1, 4, 0, 0, 1, 1, 1, 1,
     &default_syntax, 0, NULL,
-    {0, 0, 1, {0}},
+    {0, 0, 1, 0},
 };
 
 sig_atomic_t syntax_yield = 0; // flag set by the SIGALRM handler
-bool syntax_change = 0; // used to reset syntax highlighting state
+bool syntax_change = 0; // used to update syntax highlighting
 
 void sighandler(int x) {
     signal(SIGALRM, sighandler);
@@ -100,9 +100,9 @@ int main(int argc, char **argv) {
     read_lines();
     if (fp) fclose(fp);
     detect_read_only(filename);
+    memset(&lines[0].state, 0, sizeof(lines[0].state)); // reset first line state
 
     signal(SIGALRM, sighandler);
-    init_syntax_state(&config.selected_buf.syntax_state);
     bool syntax_todo = syntaxHighlight() == SYNTAX_TODO;
 
     while (1) {
@@ -132,11 +132,7 @@ int main(int argc, char **argv) {
         process_keypress(c);
 
         if (syntax_todo || syntax_change) {// call syntaxHighlight after processing char
-            if (syntax_change) { // reset syntax state before calling syntaxHighlight
-                syntax_change = 0;
-                syntax_yield = 0;
-                init_syntax_state(&config.selected_buf.syntax_state);
-            }
+            syntax_change = 0, syntax_yield = 0;
             syntax_todo = syntaxHighlight() == SYNTAX_TODO;
         }
     }

--- a/src/ted.c
+++ b/src/ted.c
@@ -31,6 +31,7 @@ struct CFG config = {
 sig_atomic_t syntax_yield = 0; // flag set by the SIGALRM handler
 bool syntax_change = 0; // used to update syntax highlighting
 bool syntax_update_fast = 0; // update only as little as possible
+bool syntax_matched = 0; // at least 1 match was found
 
 void sighandler(int x) {
     signal(SIGALRM, sighandler);

--- a/src/ted.h
+++ b/src/ted.h
@@ -228,6 +228,7 @@ extern const char *substitute_string;
 extern sig_atomic_t syntax_yield;
 extern bool syntax_change;
 extern bool syntax_update_fast;
+extern bool syntax_matched;
 
 #endif
 

--- a/src/ted.h
+++ b/src/ted.h
@@ -88,7 +88,8 @@ int utf8ToMultibyte(uchar32_t c, unsigned char *out, bool validate);
 bool validate_utf8(unsigned char *ucs);
 
 // color.c
-void set_syntax_change(unsigned int at);
+void set_syntax_change(unsigned int at, bool update_fast);
+void reset_brackets(void);
 int syntaxHighlight(void);
 void readColor(unsigned int at, unsigned int at1, unsigned char *fg, unsigned char *bg);
 
@@ -132,10 +133,11 @@ struct SHD {
     const char *word_separators;
     unsigned int kwdlen;
     struct KWD *keywords;
+    unsigned int match_color;// color of match
     unsigned char string_color;
     unsigned char stringmatch_color;
     unsigned char comment_color;
-    unsigned char match_color;
+    unsigned char hover_match_color;// color of match when cursor is on them
     unsigned char number_color;
     unsigned char number_prefix_color;
     unsigned char number_suffix_color;
@@ -163,6 +165,8 @@ struct BUFFER {
     bool read_only;
     bool can_write;
     unsigned int syntax_at;
+    unsigned int brackets_len;
+    struct CURSOR *highlighted_brackets;// store the positions of highlighted brackets that need to be resetted
 };
 
 struct CFG {

--- a/src/ted.h
+++ b/src/ted.h
@@ -89,7 +89,6 @@ bool validate_utf8(unsigned char *ucs);
 
 // color.c
 void set_syntax_change(unsigned int at, bool update_fast);
-void reset_brackets(void);
 int syntaxHighlight(void);
 void readColor(unsigned int at, unsigned int at1, unsigned char *fg, unsigned char *bg);
 
@@ -165,8 +164,6 @@ struct BUFFER {
     bool read_only;
     bool can_write;
     unsigned int syntax_at;
-    unsigned int brackets_len;
-    struct CURSOR *highlighted_brackets;// store the positions of highlighted brackets that need to be resetted
 };
 
 struct CFG {

--- a/src/ted.h
+++ b/src/ted.h
@@ -88,6 +88,7 @@ int utf8ToMultibyte(uchar32_t c, unsigned char *out, bool validate);
 bool validate_utf8(unsigned char *ucs);
 
 // color.c
+void set_syntax_change(unsigned int at);
 int syntaxHighlight(void);
 void readColor(unsigned int at, unsigned int at1, unsigned char *fg, unsigned char *bg);
 

--- a/src/ted.h
+++ b/src/ted.h
@@ -225,6 +225,7 @@ extern const uchar32_t substitute_char;
 extern const char *substitute_string;
 extern sig_atomic_t syntax_yield;
 extern bool syntax_change;
+extern bool syntax_update_fast;
 
 #endif
 

--- a/src/ted.h
+++ b/src/ted.h
@@ -142,10 +142,10 @@ struct SHD {
     const char *stringchars;
     unsigned int stringmatch_len;
     const struct MATCH *stringmatch;
-    const char *singleline_comment;
-    const char *multiline_comment[2];
+    const struct MATCH singleline_comment;
+    const struct MATCH multiline_comment[2];
     const char *match[2];
-    const char *number_prefix[3]; // 0: hexadecimal 1: octal 2: binary
+    const struct MATCH number_prefix[3]; // 0: hexadecimal 1: octal 2: binary
     const char *number_suffixes;
     const char *number_strings[4]; // 0: hexadecimal 1: octal 2: binary 3: decimal
 };
@@ -156,16 +156,10 @@ struct SHSTATE {
     bool backslash;
     char string;
     unsigned int waiting_to_close;
-    unsigned int slinecommentlen;
-    unsigned int mlinecommentstart;
-    unsigned int mlinecommentend;
-    unsigned int hexprefixlen;
-    unsigned int octprefixlen;
-    unsigned int binprefixlen;
     unsigned int at_line;
 };
 
-void init_syntax_state(struct SHSTATE *state, struct SHD *syntax);
+void init_syntax_state(struct SHSTATE *state);
 
 struct BUFFER {
     bool modified;

--- a/src/ted.h
+++ b/src/ted.h
@@ -33,8 +33,8 @@
 #define SYNTAX_END  -1  // syntaxHighlight highlighted all the file
 #define SYNTAX_TODO -2  // syntaxHighlight didn't finish yet
 
-#define INPUT_TIMEOUT  5     //timeout for input in ncurses (in milliseconds)
-#define SYNTAX_TIMEOUT 30000 //time slice in which syntaxHighlight runs (in microseconds) (30 milliseconds)
+#define INPUT_TIMEOUT  10    //timeout for input in ncurses (in milliseconds)
+#define SYNTAX_TIMEOUT 25000 //time slice in which syntaxHighlight runs (in microseconds) (25 milliseconds)
 
 typedef uint32_t uchar32_t;
 
@@ -126,7 +126,6 @@ Syntax Highlighting Descriptor
 */
 struct SHD {
     const char *name;
-    bool limited_scroll; // if set syntaxHighlight won't scroll over all the source
     unsigned int exts_len;
     const char **extensions;
     const char *word_separators;
@@ -156,16 +155,13 @@ struct SHSTATE {
     bool backslash;
     char string;
     unsigned int waiting_to_close;
-    unsigned int at_line;
 };
-
-void init_syntax_state(struct SHSTATE *state);
 
 struct BUFFER {
     bool modified;
     bool read_only;
     bool can_write;
-    struct SHSTATE syntax_state;
+    unsigned int syntax_at;
 };
 
 struct CFG {
@@ -183,7 +179,6 @@ struct CFG {
     struct BUFFER selected_buf;
 };
 
-
 /*
 ffffbbbb
 00000000 == default with default background
@@ -200,9 +195,8 @@ struct LINE {
     unsigned char *color;
     unsigned int length;
     unsigned int ident;
-    bool multiline_comment;
+    struct SHSTATE state;
 };
-
 
 struct CURSOR {
     unsigned int x;

--- a/src/utils.c
+++ b/src/utils.c
@@ -107,8 +107,7 @@ struct LINE blank_line(void) {
     ln.color = calloc(ln.len, sizeof(*ln.color));
     ln.length = 0;
     ln.ident = 0;
-    ln.multiline_comment = 0;
-
     *ln.data = '\0';
+
     return ln;
 }

--- a/src/utils.c
+++ b/src/utils.c
@@ -109,5 +109,7 @@ struct LINE blank_line(void) {
     ln.ident = 0;
     *ln.data = '\0';
 
+    memset(&ln.state, 0, sizeof(ln.state));
+
     return ln;
 }


### PR DESCRIPTION
Store a struct SHSTATE on every line (only 8 additional bytes on my machine) so that syntaxHighlight doesn't need to loop on the whole file for every modification, but only from cy - 1 to num_lines. (*)

(*) This  can be further improved by stopping the highlighting when no multiline comment/string/etc is modified and returning early.

~~Seems to work fine for what I have tested.~~
This is also related to #59 