### PR TITLE
Keep syntax matches length statically

### DIFF
--- a/src/color.c
+++ b/src/color.c
@@ -9,6 +9,10 @@ void init_syntax_state(struct SHSTATE *state) {
 }
 
 int syntaxHighlight(void) {
+    struct itimerval interval = {0}, zeroed = {0};// set preemptive timer
+    interval.it_value.tv_usec = SYNTAX_TIMEOUT;
+    setitimer(ITIMER_REAL, &interval, NULL);
+
     if (config.current_syntax == &default_syntax) {// just reset color to all lines
         for (unsigned int at = config.selected_buf.syntax_state.at_line; at < num_lines; at++) {
             if (syntax_yield) {
@@ -20,22 +24,17 @@ int syntaxHighlight(void) {
         }
         goto END;
     }
-    // restore saved state
+    //todo: these are superfluous
     bool multi_line_comment = config.selected_buf.syntax_state.multi_line_comment;
     bool backslash = config.selected_buf.syntax_state.backslash;
     char string = config.selected_buf.syntax_state.string;
     unsigned int waiting_to_close = config.selected_buf.syntax_state.waiting_to_close;
-
-    unsigned int slinecommentlen = config.current_syntax->singleline_comment.length; //todo: these are superfluous
+    unsigned int slinecommentlen = config.current_syntax->singleline_comment.length; 
     unsigned int mlinecommentstart = config.current_syntax->multiline_comment[0].length;
     unsigned int mlinecommentend = config.current_syntax->multiline_comment[1].length;
     unsigned int hexprefixlen = config.current_syntax->number_prefix[0].length;
     unsigned int octprefixlen = config.current_syntax->number_prefix[1].length;
     unsigned int binprefixlen = config.current_syntax->number_prefix[2].length;
-
-    struct itimerval interval = {0}, zeroed = {0};// set preemptive timer
-    interval.it_value.tv_usec = SYNTAX_TIMEOUT;
-    setitimer(ITIMER_REAL, &interval, NULL);
 
     for (unsigned int at = config.selected_buf.syntax_state.at_line; at < num_lines; at++) {
         if (syntax_yield) {//save state

--- a/src/syntax.c
+++ b/src/syntax.c
@@ -112,9 +112,9 @@ static struct SHD c_syntax = {
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, LITERAL_COLOR, TYPES_COLOR,
     "\"\'", sizeof c_cpp_number_strmatch / sizeof *c_cpp_number_strmatch, c_cpp_number_strmatch,// Strings charaters
-    "//", {"/*", "*/"}, // Comments
+    STRMATCH("//"), {STRMATCH("/*"), STRMATCH("*/")}, // Comments
     {"{[(", "}])"},
-    {"0x", "0", ""},
+    {STRMATCH("0x"), STRMATCH("0"), STRMATCH("")},
     c_cpp_number_suffixes,
     {"0123456789aAbBcCdDeEfF", "01234567", "01", "0123456789"}
 };
@@ -243,9 +243,9 @@ static struct SHD cpp_syntax = {
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, LITERAL_COLOR, TYPES_COLOR,
     "\"\'", sizeof c_cpp_number_strmatch / sizeof *c_cpp_number_strmatch, c_cpp_number_strmatch,// Strings charaters
-    "//", {"/*", "*/"}, // Comments
+    STRMATCH("//"), {STRMATCH("/*"), STRMATCH("*/")}, // Comments
     {"{[(", "}])"},
-    {"0x", "0", "0b"},
+    {STRMATCH("0x"), STRMATCH("0"), STRMATCH("0b")},
     c_cpp_number_suffixes,
     {"0123456789aAbBcCdDeEfF'", "01234567'", "01'", "0123456789'"} // ' is a digit divisor
 };
@@ -356,9 +356,9 @@ static struct SHD python_syntax = {
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, LITERAL_COLOR, TYPES_COLOR,
     "\"\'`", sizeof python_strmatch / sizeof *python_strmatch, python_strmatch,// Strings charaters
-    "#", {"", ""}, // Comments
+    STRMATCH("#"), {STRMATCH(""), STRMATCH("")}, // Comments
     {"{[(", "}])"},
-    {"0x", "0o", "0b"},
+    {STRMATCH("0x"), STRMATCH("0o"), STRMATCH("0b")},
     "jJ",
     {"0123456789aAbBcCdDeEfF_", "01234567_", "01_", "0123456789_"} // _ is a digit divisor
 };
@@ -421,9 +421,9 @@ static struct SHD sh_syntax = {
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, 0, 0,
     "\"\'`", sizeof sh_strmatch / sizeof *sh_strmatch, sh_strmatch, // Strings charaters
-    "#", {"", ""}, // Comments
+    STRMATCH("#"), {STRMATCH(""), STRMATCH("")}, // Comments
     {"{[(", "}])"},
-    {"", "", ""},
+    {STRMATCH(""), STRMATCH(""), STRMATCH("")},
     "",
     {"0123456789aAbBcCdDeEfF", "01234567", "01", "0123456789"}
 };
@@ -522,9 +522,9 @@ static struct SHD rust_syntax = {
     PALETTE_COLOR(PALETTE_CYAN, PALETTE_OFF), PALETTE_COLOR(PALETTE_OFF, PALETTE_CYAN),
     LITERAL_COLOR, LITERAL_COLOR, TYPES_COLOR,
     "\"", sizeof rust_strmatch / sizeof *rust_strmatch, rust_strmatch,// Strings charaters
-    "//", {"/*", "*/"}, // Comments
+    STRMATCH("//"), {STRMATCH("/*"), STRMATCH("*/")}, // Comments
     {"{[(", "}])"},
-    {"0x", "0o", "0b"},
+    {STRMATCH("0x"), STRMATCH("0o"), STRMATCH("0b")},
     "uif816324sze",
     {"0123456789aAbBcCdDeEfF_", "01234567_", "01_", "0123456789_"} // _ is a digit divisor
 };
@@ -540,9 +540,9 @@ struct SHD default_syntax = {
     0, NULL,
     0, 0, 0, 0, 0, 0, 0,
     "", 0, NULL,
-    "", {"", ""},
+    STRMATCH(""), {STRMATCH(""), STRMATCH("")},
     {"", ""},
-    {"", "", ""},
+    {STRMATCH(""), STRMATCH(""), STRMATCH("")},
     "",
     {"", "", "", ""}
 };

--- a/src/ted.c
+++ b/src/ted.c
@@ -102,7 +102,7 @@ int main(int argc, char **argv) {
     detect_read_only(filename);
 
     signal(SIGALRM, sighandler);
-    init_syntax_state(&config.selected_buf.syntax_state, config.current_syntax);
+    init_syntax_state(&config.selected_buf.syntax_state);
     bool syntax_todo = syntaxHighlight() == SYNTAX_TODO;
 
     while (1) {
@@ -135,7 +135,7 @@ int main(int argc, char **argv) {
             if (syntax_change) { // reset syntax state before calling syntaxHighlight
                 syntax_change = 0;
                 syntax_yield = 0;
-                init_syntax_state(&config.selected_buf.syntax_state, config.current_syntax);
+                init_syntax_state(&config.selected_buf.syntax_state);
             }
             syntax_todo = syntaxHighlight() == SYNTAX_TODO;
         }

--- a/src/ted.h
+++ b/src/ted.h
@@ -142,10 +142,10 @@ struct SHD {
     const char *stringchars;
     unsigned int stringmatch_len;
     const struct MATCH *stringmatch;
-    const char *singleline_comment;
-    const char *multiline_comment[2];
+    const struct MATCH singleline_comment;
+    const struct MATCH multiline_comment[2];
     const char *match[2];
-    const char *number_prefix[3]; // 0: hexadecimal 1: octal 2: binary
+    const struct MATCH number_prefix[3]; // 0: hexadecimal 1: octal 2: binary
     const char *number_suffixes;
     const char *number_strings[4]; // 0: hexadecimal 1: octal 2: binary 3: decimal
 };
@@ -156,16 +156,10 @@ struct SHSTATE {
     bool backslash;
     char string;
     unsigned int waiting_to_close;
-    unsigned int slinecommentlen;
-    unsigned int mlinecommentstart;
-    unsigned int mlinecommentend;
-    unsigned int hexprefixlen;
-    unsigned int octprefixlen;
-    unsigned int binprefixlen;
     unsigned int at_line;
 };
 
-void init_syntax_state(struct SHSTATE *state, struct SHD *syntax);
+void init_syntax_state(struct SHSTATE *state);
 
 struct BUFFER {
     bool modified;


### PR DESCRIPTION
This is only a little optimization taken from #60 that stores the length of matches statically instead of using strlen